### PR TITLE
refactor: do checksum and serializing in parallel

### DIFF
--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
 use tempfile::TempDir;
-use yek::{config::FullYekConfig, serialize_repo};
+use yek::{config::YekConfig, serialize_repo};
 
 /// Creates a text file of a specified size in bytes.
 fn create_test_data_bytes(dir: &Path, size: usize, file_name: &str) {
@@ -60,7 +60,7 @@ fn bench_single_small_file(c: &mut Criterion) {
                 output_dir
             },
             |output_dir| {
-                let config = FullYekConfig::extend_config_with_defaults(
+                let config = YekConfig::extend_config_with_defaults(
                     vec![temp_dir.path().to_string_lossy().to_string()],
                     output_dir.to_string_lossy().to_string(),
                 );
@@ -85,7 +85,7 @@ fn single_large_file_byte_mode(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(size as u64));
     group.bench_function("single_large_file", |b| {
         b.iter(|| {
-            let config = FullYekConfig::extend_config_with_defaults(
+            let config = YekConfig::extend_config_with_defaults(
                 vec![temp_dir.path().to_string_lossy().to_string()],
                 output_dir.to_string_lossy().to_string(),
             );
@@ -108,7 +108,7 @@ fn single_large_file_token_mode(c: &mut Criterion) {
     group.throughput(Throughput::Elements(token_count as u64));
     group.bench_function("single_large_token_file", |b| {
         b.iter(|| {
-            let config = FullYekConfig::extend_config_with_defaults(
+            let config = YekConfig::extend_config_with_defaults(
                 vec![temp_dir.path().to_string_lossy().to_string()],
                 output_dir.to_string_lossy().to_string(),
             );
@@ -132,7 +132,7 @@ fn multiple_small_files(c: &mut Criterion) {
                 (temp_dir, output_dir)
             },
             |(temp_dir, output_dir)| {
-                let config = FullYekConfig::extend_config_with_defaults(
+                let config = YekConfig::extend_config_with_defaults(
                     vec![temp_dir.path().to_string_lossy().to_string()],
                     output_dir.to_string_lossy().to_string(),
                 );
@@ -161,7 +161,7 @@ fn multiple_medium_files(c: &mut Criterion) {
                 (temp_dir, output_dir)
             },
             |(temp_dir, output_dir)| {
-                let config = FullYekConfig::extend_config_with_defaults(
+                let config = YekConfig::extend_config_with_defaults(
                     vec![temp_dir.path().to_string_lossy().to_string()],
                     output_dir.to_string_lossy().to_string(),
                 );
@@ -187,7 +187,7 @@ fn multiple_large_files(c: &mut Criterion) {
                 (temp_dir, output_dir)
             },
             |(temp_dir, output_dir)| {
-                let config = FullYekConfig::extend_config_with_defaults(
+                let config = YekConfig::extend_config_with_defaults(
                     vec![temp_dir.path().to_string_lossy().to_string()],
                     output_dir.to_string_lossy().to_string(),
                 );
@@ -213,7 +213,7 @@ fn multiple_token_files(c: &mut Criterion) {
                 (temp_dir, output_dir)
             },
             |(temp_dir, output_dir)| {
-                let config = FullYekConfig::extend_config_with_defaults(
+                let config = YekConfig::extend_config_with_defaults(
                     vec![temp_dir.path().to_string_lossy().to_string()],
                     output_dir.to_string_lossy().to_string(),
                 );
@@ -231,7 +231,7 @@ fn custom_config_test(c: &mut Criterion) {
     let mut group = c.benchmark_group("CustomConfig");
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("output");
-    let config_template = FullYekConfig::extend_config_with_defaults(
+    let config_template = YekConfig::extend_config_with_defaults(
         vec![temp_dir.path().to_string_lossy().to_string()],
         output_dir.to_string_lossy().to_string(),
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,275 +69,236 @@ pub struct YekConfig {
     /// Maximum additional boost from Git commit times (0..1000)
     #[config_arg(accept_from = "config_only")]
     pub git_boost_max: Option<i32>,
-}
 
-#[derive(Clone, serde::Serialize)]
-pub struct FullYekConfig {
-    #[serde(flatten)]
-    pub base: YekConfig,
-    /// Stream output to stdout
+    /// True if we should stream output to stdout (computed)
     pub stream: bool,
-    /// Use token mode instead of byte mode
+
+    /// True if we should count tokens, not bytes (computed)
     pub token_mode: bool,
-    /// The full path to the output file
-    pub output_file_full_path: String,
+
+    /// Final resolved output file path (only used if not streaming)
+    pub output_file_full_path: Option<String>,
 }
 
-impl std::ops::Deref for FullYekConfig {
-    type Target = YekConfig;
+/// Provide defaults so tests or other callers can create a baseline YekConfig easily.
+impl Default for YekConfig {
+    fn default() -> Self {
+        Self {
+            input_dirs: Vec::new(),
+            max_size: "10MB".to_string(),
+            tokens: String::new(),
+            json: false,
+            debug: false,
+            output_dir: None,
+            output_template: DEFAULT_OUTPUT_TEMPLATE.to_string(),
+            ignore_patterns: Vec::new(),
+            unignore_patterns: Vec::new(),
+            priority_rules: Vec::new(),
+            binary_extensions: BINARY_FILE_EXTENSIONS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            git_boost_max: Some(100),
 
-    fn deref(&self) -> &Self::Target {
-        &self.base
-    }
-}
-
-impl std::ops::DerefMut for FullYekConfig {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.base
-    }
-}
-
-impl FullYekConfig {
-    pub fn extend_config_with_defaults(
-        input_dirs: Vec<String>,
-        output_dir: String,
-    ) -> FullYekConfig {
-        let token_mode = false;
-        let checksum = get_checksum(&input_dirs);
-        let extension = if token_mode { "tok" } else { "txt" };
-        let output_file_full_path = Path::new(&output_dir)
-            .join(format!("yek-output-{}.{}", checksum, extension))
-            .to_string_lossy()
-            .to_string();
-
-        FullYekConfig {
-            base: YekConfig {
-                input_dirs,
-                output_dir: Some(output_dir),
-                max_size: "10MB".to_string(),
-                tokens: String::new(),
-                json: false,
-                debug: false,
-                output_template: DEFAULT_OUTPUT_TEMPLATE.to_string(),
-                ignore_patterns: Vec::new(),
-                unignore_patterns: Vec::new(),
-                priority_rules: Vec::new(),
-                binary_extensions: Vec::new(),
-                git_boost_max: Some(100),
-            },
+            // computed fields
             stream: false,
             token_mode: false,
-            output_file_full_path,
+            output_file_full_path: None,
         }
     }
-}
-
-fn get_checksum(input_dirs: &Vec<String>) -> String {
-    let mut hasher = Sha256::new();
-    for dir in input_dirs {
-        let base_path = Path::new(dir);
-        if !base_path.exists() {
-            continue;
-        }
-        let entries = match fs::read_dir(base_path) {
-            Ok(iter) => iter.filter_map(|e| e.ok()).collect::<Vec<_>>(),
-            Err(_) => continue,
-        };
-
-        // Sort deterministically by path name
-        let mut sorted = entries;
-        sorted.sort_by_key(|a| a.path());
-
-        for entry in sorted {
-            let p = entry.path();
-            // We only do metadata-based hashing for the immediate listing
-            if let Ok(meta) = fs::metadata(&p) {
-                // Include path in hash
-                let path_str = p.to_string_lossy();
-                hasher.update(path_str.as_bytes());
-
-                // Include file size
-                hasher.update(meta.len().to_le_bytes());
-
-                // Include modified time
-                if let Ok(mod_time) = meta.modified() {
-                    if let Ok(dur) = mod_time.duration_since(UNIX_EPOCH) {
-                        hasher.update(dur.as_secs().to_le_bytes());
-                    }
-                }
-            }
-        }
-    }
-    let result = hasher.finalize();
-    format!("{:x}", result)
 }
 
 impl YekConfig {
-    /// Initialize the config from CLI arguments + optional `yek.toml`.
-    pub fn init_config() -> FullYekConfig {
-        let mut config = YekConfig::parse();
+    pub fn extend_config_with_defaults(input_dirs: Vec<String>, output_dir: String) -> Self {
+        YekConfig {
+            input_dirs,
+            output_dir: Some(output_dir),
+            ..Default::default()
+        }
+    }
+}
 
-        // Compute values that are computed
-        let token_mode = !config.tokens.is_empty();
-        let stream = !std::io::stdout().is_terminal();
-
-        // Default input dirs to current dir if not provided
-        if config.input_dirs.is_empty() {
-            config.input_dirs.push(".".to_string());
+impl YekConfig {
+    /// Ensure output directory exists and is valid. Returns the resolved output directory path.
+    fn ensure_output_dir(&self) -> Result<String> {
+        if self.stream {
+            return Ok(String::new());
         }
 
-        // Extend binary extensions with defaults
-        config
-            .binary_extensions
-            .extend(BINARY_FILE_EXTENSIONS.iter().map(|s| s.to_string()));
+        let output_dir = if let Some(dir) = &self.output_dir {
+            dir.clone()
+        } else {
+            let temp_dir = std::env::temp_dir().join("yek-output");
+            temp_dir.to_string_lossy().to_string()
+        };
 
-        // Always start with default ignore patterns
-        let mut ignore_patterns = DEFAULT_IGNORE_PATTERNS
+        let path = Path::new(&output_dir);
+        if path.exists() && !path.is_dir() {
+            return Err(anyhow!(
+                "output_dir: '{}' exists but is not a directory",
+                output_dir
+            ));
+        }
+
+        std::fs::create_dir_all(path)
+            .map_err(|e| anyhow!("output_dir: cannot create '{}': {}", output_dir, e))?;
+
+        Ok(output_dir)
+    }
+
+    /// Parse from CLI + config file, fill in computed fields, and validate.
+    pub fn init_config() -> Self {
+        // 1) parse from CLI and optional config file:
+        let mut cfg = YekConfig::parse();
+
+        // 2) compute derived fields:
+        cfg.token_mode = !cfg.tokens.is_empty();
+        let force_tty = std::env::var("FORCE_TTY").is_ok();
+
+        cfg.stream = !std::io::stdout().is_terminal() && !force_tty;
+
+        // default input dirs to current dir if none:
+        if cfg.input_dirs.is_empty() {
+            cfg.input_dirs.push(".".to_string());
+        }
+
+        // Extend binary extensions with the built-in list:
+        let mut merged_bins = BINARY_FILE_EXTENSIONS
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
+        merged_bins.append(&mut cfg.binary_extensions);
+        cfg.binary_extensions = merged_bins;
 
-        // Add user-specified ignore patterns
-        ignore_patterns.extend(config.ignore_patterns);
-        config.ignore_patterns = ignore_patterns;
+        // Always start with default ignore patterns, then add user's:
+        let mut ignore = DEFAULT_IGNORE_PATTERNS
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        ignore.extend(cfg.ignore_patterns);
+        cfg.ignore_patterns = ignore;
 
-        // Apply unignore patterns to ignore patterns
-        config
-            .ignore_patterns
-            .extend(config.unignore_patterns.iter().map(|s|
-            // Change the glob to a negative glob by adding ! to the beginning
-            format!("!{}", s)));
+        // Apply unignore patterns (turn them into negative globs "!…")
+        cfg.ignore_patterns
+            .extend(cfg.unignore_patterns.iter().map(|pat| format!("!{}", pat)));
 
-        // Default the output dir to a temp dir if not provided
-        let output_dir = if let Some(dir) = config.output_dir {
-            dir
-        } else {
-            let temp_dir = std::env::temp_dir();
-            let output_dir = temp_dir.join("yek-output");
-            std::fs::create_dir_all(&output_dir).unwrap();
-            output_dir.to_string_lossy().to_string()
-        };
+        // Handle output directory setup
+        if !cfg.stream {
+            if let Ok(dir) = cfg.ensure_output_dir() {
+                cfg.output_dir = Some(dir);
+            }
+        }
 
-        let checksum = get_checksum(&config.input_dirs);
-        let extension = if config.json { "json" } else { "txt" };
-        // Make the output file name based on checksum of input dirs contents
-        let output_file_full_path = Path::new(&output_dir)
-            .join(format!("yek-output-{}.{}", checksum, extension))
-            .to_string_lossy()
-            .to_string();
+        // By default, we start with no final output_file_full_path:
+        cfg.output_file_full_path = None;
 
-        let final_config = FullYekConfig {
-            base: YekConfig {
-                input_dirs: config.input_dirs.clone(),
-                output_dir: Some(output_dir),
-                max_size: config.max_size.clone(),
-                tokens: config.tokens.clone(),
-                json: config.json,
-                debug: config.debug,
-                output_template: config.output_template.clone(),
-                ignore_patterns: config.ignore_patterns.clone(),
-                unignore_patterns: config.unignore_patterns.clone(),
-                priority_rules: config.priority_rules.clone(),
-                binary_extensions: config.binary_extensions.clone(),
-                git_boost_max: config.git_boost_max,
-            },
-            stream,
-            token_mode,
-            output_file_full_path,
-        };
-
-        // Validate the config
-        if let Err(e) = validate_config(&final_config) {
+        // 3) Validate
+        if let Err(e) = cfg.validate() {
             eprintln!("Error: {}", e);
             std::process::exit(1);
         }
 
-        final_config
-    }
-}
-
-pub struct ConfigError {
-    pub field: String,
-    pub message: String,
-}
-
-pub fn validate_config(config: &FullYekConfig) -> Result<()> {
-    // Validate output template
-    if !config.base.output_template.contains("FILE_PATH")
-        || !config.base.output_template.contains("FILE_CONTENT")
-    {
-        return Err(anyhow!(
-            "output_template: Output template must contain FILE_PATH and FILE_CONTENT"
-        ));
+        cfg
     }
 
-    // Validate max_size
-    if config.base.max_size == "0" {
-        return Err(anyhow!("max_size: Max size cannot be 0"));
-    }
+    /// Compute a quick checksum for the *top-level listing* of each input dir.
+    pub fn get_checksum(input_dirs: &[String]) -> String {
+        let mut hasher = Sha256::new();
+        for dir in input_dirs {
+            let base_path = Path::new(dir);
+            if !base_path.exists() {
+                continue;
+            }
+            let entries = match fs::read_dir(base_path) {
+                Ok(iter) => iter.filter_map(|e| e.ok()).collect::<Vec<_>>(),
+                Err(_) => continue,
+            };
 
-    if !config.token_mode {
-        ByteSize::from_str(&config.base.max_size)
-            .map_err(|e| anyhow!("max_size: Invalid size format: {}", e))?;
-    } else if config.base.tokens.to_lowercase().ends_with('k') {
-        let val = config.base.tokens[..config.base.tokens.len() - 1]
-            .trim()
-            .parse::<usize>()
-            .map_err(|e| anyhow!("tokens: Invalid token size: {}", e))?;
-        if val == 0 {
-            return Err(anyhow!("tokens: Token size cannot be 0"));
+            // Sort deterministically by path name
+            let mut sorted = entries;
+            sorted.sort_by_key(|a| a.path());
+
+            for entry in sorted {
+                let p = entry.path();
+                if let Ok(meta) = fs::metadata(&p) {
+                    let path_str = p.to_string_lossy();
+                    hasher.update(path_str.as_bytes());
+                    hasher.update(meta.len().to_le_bytes());
+
+                    if let Ok(mod_time) = meta.modified() {
+                        if let Ok(dur) = mod_time.duration_since(UNIX_EPOCH) {
+                            hasher.update(dur.as_secs().to_le_bytes());
+                        }
+                    }
+                }
+            }
         }
-    } else {
-        let val = config
-            .base
-            .tokens
-            .parse::<usize>()
-            .map_err(|e| anyhow!("tokens: Invalid token size: {}", e))?;
-        if val == 0 {
-            return Err(anyhow!("tokens: Token size cannot be 0"));
-        }
+        let result = hasher.finalize();
+        // Convert the 32-byte result to hex, but only keep the first 8 characters
+        let hex = format!("{:x}", result);
+        hex[..8].to_owned()
     }
 
-    // Validate output directory if specified
-    let output_dir = config
-        .base
-        .output_dir
-        .as_ref()
-        .ok_or_else(|| anyhow!("output_dir: Output directory must be specified"))?;
-
-    let path = Path::new(output_dir);
-    if path.exists() && !path.is_dir() {
-        return Err(anyhow!(
-            "output_dir: Output path '{}' exists but is not a directory",
-            output_dir
-        ));
-    }
-
-    // Validate ignore patterns
-    for pattern in &config.base.ignore_patterns {
-        glob::Pattern::new(pattern)
-            .map_err(|e| anyhow!("ignore_patterns: Invalid pattern '{}': {}", pattern, e))?;
-    }
-
-    // Validate priority rules
-    for rule in &config.base.priority_rules {
-        if rule.score < 0 || rule.score > 1000 {
+    /// Validate the final config.
+    pub fn validate(&self) -> Result<()> {
+        if !self.output_template.contains("FILE_PATH")
+            || !self.output_template.contains("FILE_CONTENT")
+        {
             return Err(anyhow!(
-                "priority_rules: Priority score {} must be between 0 and 1000",
-                rule.score
+                "output_template: must contain FILE_PATH and FILE_CONTENT"
             ));
         }
-        glob::Pattern::new(&rule.pattern)
-            .map_err(|e| anyhow!("priority_rules: Invalid pattern '{}': {}", rule.pattern, e))?;
-    }
 
-    if let Err(e) = std::fs::create_dir_all(path) {
-        return Err(anyhow!(
-            "output_dir: Cannot create output directory '{}': {}",
-            output_dir,
-            e
-        ));
-    }
+        if self.max_size == "0" {
+            return Err(anyhow!("max_size: cannot be 0"));
+        }
 
-    Ok(())
+        if !self.token_mode {
+            ByteSize::from_str(&self.max_size)
+                .map_err(|e| anyhow!("max_size: Invalid size format: {}", e))?;
+        } else if self.tokens.to_lowercase().ends_with('k') {
+            let val = self.tokens[..self.tokens.len() - 1]
+                .trim()
+                .parse::<usize>()
+                .map_err(|e| anyhow!("tokens: Invalid token size: {}", e))?;
+            if val == 0 {
+                return Err(anyhow!("tokens: cannot be 0"));
+            }
+        } else if !self.tokens.is_empty() {
+            // parse as integer
+            let val = self
+                .tokens
+                .parse::<usize>()
+                .map_err(|e| anyhow!("tokens: Invalid token size: {}", e))?;
+            if val == 0 {
+                return Err(anyhow!("tokens: cannot be 0"));
+            }
+        }
+
+        // If not streaming, validate output directory
+        if !self.stream {
+            self.ensure_output_dir()?;
+        }
+
+        // Validate ignore patterns
+        for pattern in &self.ignore_patterns {
+            glob::Pattern::new(pattern)
+                .map_err(|e| anyhow!("ignore_patterns: Invalid pattern '{}': {}", pattern, e))?;
+        }
+
+        // Validate priority rules
+        for rule in &self.priority_rules {
+            if rule.score < 0 || rule.score > 1000 {
+                return Err(anyhow!(
+                    "priority_rules: Priority score {} must be between 0 and 1000",
+                    rule.score
+                ));
+            }
+            glob::Pattern::new(&rule.pattern).map_err(|e| {
+                anyhow!("priority_rules: Invalid pattern '{}': {}", rule.pattern, e)
+            })?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,30 +78,29 @@ pub fn serialize_repo(config: &YekConfig) -> Result<(String, Vec<ProcessedFile>)
     });
 
     // Build the final output string
-    let output_string = concat_files(files.clone(), config);
+    let output_string = concat_files(&files, config)?;
 
     Ok((output_string, files))
 }
 
-fn concat_files(files: Vec<ProcessedFile>, config: &YekConfig) -> String {
+fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Result<String> {
     if config.json {
         // JSON array of objects
-        serde_json::to_string_pretty(
+        Ok(serde_json::to_string_pretty(
             &files
-                .into_iter()
+                .iter()
                 .map(|f| {
                     serde_json::json!({
-                        "filename": f.rel_path,
-                        "content": f.content,
+                        "filename": &f.rel_path,
+                        "content": &f.content,
                     })
                 })
                 .collect::<Vec<_>>(),
-        )
-        .unwrap()
+        )?)
     } else {
         // Use the user-defined template
-        files
-            .into_iter()
+        Ok(files
+            .iter()
             .map(|f| {
                 config
                     .output_template
@@ -111,6 +110,6 @@ fn concat_files(files: Vec<ProcessedFile>, config: &YekConfig) -> String {
                     .replace("\\\n", "\n")
             })
             .collect::<Vec<_>>()
-            .join("\n")
+            .join("\n"))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use content_inspector::{inspect, ContentType};
 use rayon::prelude::*;
 use std::{
     collections::HashMap,
-    fs::{self, File},
-    io::{self, Read, Write},
+    fs::File,
+    io::{self, Read},
     path::Path,
 };
 
@@ -13,7 +13,7 @@ pub mod defaults;
 mod parallel;
 pub mod priority;
 
-use config::FullYekConfig;
+use config::YekConfig;
 use parallel::{process_files_parallel, ProcessedFile};
 use priority::compute_recentness_boost;
 
@@ -38,7 +38,7 @@ pub fn is_text_file(path: &Path, user_binary_extensions: &[String]) -> io::Resul
 }
 
 /// Main entrypoint for serialization, used by CLI and tests
-pub fn serialize_repo(config: &FullYekConfig) -> Result<(String, Vec<ProcessedFile>)> {
+pub fn serialize_repo(config: &YekConfig) -> Result<(String, Vec<ProcessedFile>)> {
     // Gather commit times from each input dir
     let combined_commit_times = config
         .input_dirs
@@ -80,13 +80,10 @@ pub fn serialize_repo(config: &FullYekConfig) -> Result<(String, Vec<ProcessedFi
     // Build the final output string
     let output_string = concat_files(files.clone(), config);
 
-    // Write to either stdout or to a file
-    write_output(&output_string, config)?;
-
     Ok((output_string, files))
 }
 
-fn concat_files(files: Vec<ProcessedFile>, config: &FullYekConfig) -> String {
+fn concat_files(files: Vec<ProcessedFile>, config: &YekConfig) -> String {
     if config.json {
         // JSON array of objects
         serde_json::to_string_pretty(
@@ -115,21 +112,5 @@ fn concat_files(files: Vec<ProcessedFile>, config: &FullYekConfig) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n")
-    }
-}
-
-fn write_output(content: &str, config: &FullYekConfig) -> io::Result<()> {
-    if config.stream {
-        // If piped, just print directly
-        let mut stdout = io::stdout();
-        stdout.write_all(content.as_bytes())?;
-        stdout.flush()
-    } else {
-        // Otherwise, write to the output file
-        let path = Path::new(&config.output_file_full_path);
-        if let Some(dir) = path.parent() {
-            fs::create_dir_all(dir)?;
-        }
-        fs::write(path, content.as_bytes())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 use anyhow::Result;
 use bytesize::ByteSize;
+use rayon::join;
+use std::path::Path;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 use yek::{config::YekConfig, serialize_repo};
 
 fn main() -> Result<()> {
-    // get the configuration from the config file and CLI args
-    let full_config = YekConfig::init_config();
+    // 1) Parse CLI + config files:
+    let mut full_config = YekConfig::init_config();
 
-    // Initialize tracing based on debug flag
+    // 2) Initialize tracing:
     fmt::Subscriber::builder()
         .with_max_level(if full_config.debug {
             Level::DEBUG
@@ -30,23 +32,54 @@ fn main() -> Result<()> {
         debug!("Configuration:\n{}", config_str);
     }
 
-    let (output, files) = serialize_repo(&full_config)?;
-
-    // if stream is true, print the actual output
+    // If streaming => skip checksum + read. Just do single-thread call to serialize_repo.
+    // If not streaming => run checksum + repo serialization in parallel.
     if full_config.stream {
+        let (output, files) = serialize_repo(&full_config)?;
+        // We print actual text to stdout:
         println!("{}", output);
 
-    // if it is a terminal, print the output file path
+        if full_config.debug {
+            debug!("{} files processed (streaming).", files.len());
+            debug!("Output lines: {}", output.lines().count());
+        }
     } else {
-        // if debug mode print output size and number of lines and number of files
+        // Not streaming => run repo serialization & checksum in parallel
+        let (serialization_res, checksum) = join(
+            || serialize_repo(&full_config),
+            || YekConfig::get_checksum(&full_config.input_dirs),
+        );
+
+        // Unpack results:
+        let (output, files) = serialization_res?;
+
+        // Now set the final output file with the computed checksum
+        let extension = if full_config.json { "json" } else { "txt" };
+        let output_dir = full_config
+            .output_dir
+            .as_ref()
+            .expect("output_dir must exist if not streaming");
+
+        let final_path = Path::new(output_dir)
+            .join(format!("yek-output-{}.{}", checksum, extension))
+            .to_string_lossy()
+            .to_string();
+        full_config.output_file_full_path = Some(final_path.clone());
+
+        // If debug, show stats
         if full_config.debug {
             let size = ByteSize::b(output.len() as u64);
             debug!("{} files processed", files.len());
-            debug!("{} generated", size); // human readable size
+            debug!("{} generated", size);
             debug!("{} lines generated", output.lines().count());
         }
 
-        println!("{}", full_config.output_file_full_path);
+        // Actually write the final output file.
+        // We'll do it right here (instead of inside `serialize_repo`) to ensure we use our new final_path:
+        std::fs::write(&final_path, output.as_bytes())?;
+
+        // Print path to stdout (like original code did)
+        println!("{}", final_path);
     }
 
     Ok(())

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,4 +1,4 @@
-use crate::{config::FullYekConfig, priority::get_file_priority, Result};
+use crate::{config::YekConfig, priority::get_file_priority, Result};
 use content_inspector::{inspect, ContentType};
 use ignore::gitignore::GitignoreBuilder;
 use path_slash::PathBufExt;
@@ -23,7 +23,7 @@ pub struct ProcessedFile {
 /// in a separate thread. Return the resulting `ProcessedFile` objects.
 pub fn process_files_parallel(
     base_dir: &Path,
-    config: &FullYekConfig,
+    config: &YekConfig,
     boost_map: &HashMap<String, i32>,
 ) -> Result<Vec<ProcessedFile>> {
     let mut walk_builder = ignore::WalkBuilder::new(base_dir);

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod config_tests {
-    use yek::config::{validate_config, FullYekConfig};
+    use yek::config::YekConfig;
     use yek::priority::PriorityRule;
 
     #[test]
     fn test_validate_config_valid() {
         let mut config =
-            FullYekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
+            YekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
         config.ignore_patterns = vec!["*.log".to_string()];
         config.priority_rules = vec![PriorityRule {
             pattern: ".*".to_string(),
@@ -14,30 +14,30 @@ mod config_tests {
         }];
         config.binary_extensions = vec!["bin".to_string()];
 
-        let result = validate_config(&config);
+        let result = config.validate();
         assert!(result.is_ok(), "Expected no validation errors");
     }
 
     #[test]
     fn test_validate_config_invalid_max_size() {
         let mut config =
-            FullYekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
+            YekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
         config.max_size = "0".to_string(); // Invalid
 
-        let result = validate_config(&config);
+        let result = config.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("max_size"));
     }
 
     #[test]
     fn test_validate_config_invalid_priority_rule_score() {
-        let mut config = FullYekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
+        let mut config = YekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
         config.priority_rules = vec![PriorityRule {
             pattern: "foo".to_string(),
             score: 1001,
         }];
 
-        let result = validate_config(&config);
+        let result = config.validate();
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("priority_rules"));
@@ -46,13 +46,13 @@ mod config_tests {
 
     #[test]
     fn test_validate_config_invalid_priority_rule_pattern() {
-        let mut config = FullYekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
+        let mut config = YekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
         config.priority_rules = vec![PriorityRule {
             pattern: "[".to_string(), // Invalid regex
             score: 100,
         }];
 
-        let result = validate_config(&config);
+        let result = config.validate();
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("priority_rules"));
@@ -61,10 +61,10 @@ mod config_tests {
 
     #[test]
     fn test_validate_config_invalid_ignore_pattern() {
-        let mut config = FullYekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
+        let mut config = YekConfig::extend_config_with_defaults(vec![], "/tmp/yek".to_string());
         config.ignore_patterns = vec!["[".to_string()]; // Invalid regex
 
-        let result = validate_config(&config);
+        let result = config.validate();
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("ignore_patterns"));

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -128,7 +128,13 @@ mod e2e_tests {
 
         // Ensure at least one output file exists inside the directory
         let output_files = fs::read_dir(&output_dir)?
-            .filter_map(|e| e.ok())
+            .filter_map(|e| match e {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    eprintln!("Warning: Failed to read directory entry: {}", err);
+                    None
+                }
+            })
             .collect::<Vec<_>>();
 
         assert!(

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -5,7 +5,7 @@ mod lib_tests {
     use tempfile::tempdir;
 
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
-    use yek::config::FullYekConfig;
+    use yek::config::YekConfig;
     use yek::is_text_file;
     use yek::priority::PriorityRule;
     use yek::serialize_repo;
@@ -17,8 +17,8 @@ mod lib_tests {
             .try_init();
     }
 
-    fn create_test_config(input_dirs: Vec<String>) -> FullYekConfig {
-        let mut config = FullYekConfig::extend_config_with_defaults(
+    fn create_test_config(input_dirs: Vec<String>) -> YekConfig {
+        let mut config = YekConfig::extend_config_with_defaults(
             input_dirs,
             std::env::temp_dir().to_string_lossy().to_string(),
         );


### PR DESCRIPTION

### 1. Merged `FullYekConfig` and `YekConfig`
- Combined both structs into a single `YekConfig`, removing redundancy.
- All fields (user-provided and computed) now exist in `YekConfig`, simplifying CLI and test usage.

### 2. Added `Default` Implementation
- Provides a default `YekConfig` (`YekConfig::default()`) for easier testing and initialization.
- Useful for unit tests, avoiding the need for a config file or CLI arguments.

### 3. Streaming vs. Non-Streaming Behavior
- **Streaming mode (`stdout` is not a TTY)**:
  - Skips checksum computation.
  - Calls `serialize_repo` directly. (Internally, `serialize_repo` remains parallel via Rayon.)
- **Non-streaming mode**:
  - Runs checksum computation **in parallel** with `serialize_repo` using `rayon::join`.

### 4. Shortened Checksum
- Reduced checksum hash length from 64 to 8 hex characters (`get_checksum` now returns only `hash[..8]`).
- Keeps filenames shorter and more readable.

### 5. Validation & Field Initialization Improvements
- `init_config` now:
  - Merges built-in defaults with user input.
  - Determines streaming mode.
  - Ensures `output_dir` is set correctly when not streaming.
- `validate` method enforces constraints (e.g. `max_size`, token parsing, output directory checks).