### PR TITLE
feat: allow files as input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     name: Release
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -351,7 +351,7 @@ jobs:
     name: Publish to crates.io
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     name: Release
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.event.base_ref, 'main')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -351,7 +351,7 @@ jobs:
     name: Publish to crates.io
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.event.base_ref, 'main')
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     name: Release
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -351,7 +351,7 @@ jobs:
     name: Publish to crates.io
     needs: [test, lint, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2025-02-22
+[0.20.0]: https://github.com/bodo-run/yek/compare/v0.19.0...v0.20.0
+### Bug Fixes
+
+- Handle root directory paths correctly
+- Update input_dirs to input_paths in benchmarks
+
+### Features
+
+- Allow files as input
+
+### Fix
+
+- Use absolute path in test_empty_input_defaults_to_cwd
+
+### Testing
+
+- Add integration test
+
 ## [0.19.0] - 2025-02-19
 [0.19.0]: https://github.com/bodo-run/yek/compare/v0.18.0...v0.19.0
 ### Bug Fixes
@@ -27,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - Only count tokens when debug logging is enabled
+
+### Release
+
+- V0.19.0
 
 ## [0.18.0] - 2025-02-13
 [0.18.0]: https://github.com/bodo-run/yek/compare/v0.16.0...v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "yek"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yek"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "A tool to serialize a repository into chunks of text files"
 license = "MIT"

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -245,7 +245,7 @@ fn custom_config_test(c: &mut Criterion) {
                 create_test_data_bytes(temp_dir.path(), 1024, "test.rs");
                 let output_dir = temp_dir.path().join("output");
                 let mut config = config_template.clone();
-                config.input_dirs = vec![temp_dir.path().to_string_lossy().to_string()];
+                config.input_paths = vec![temp_dir.path().to_string_lossy().to_string()];
                 config.output_dir = Some(output_dir.to_string_lossy().to_string());
                 (temp_dir, output_dir, config)
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
         // Not streaming => run repo serialization & checksum in parallel
         let (serialization_res, checksum_res) = join(
             || serialize_repo(&full_config),
-            || YekConfig::get_checksum(&full_config.input_dirs),
+            || YekConfig::get_checksum(&full_config.input_paths),
         );
 
         // Handle both results

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -25,7 +25,7 @@ fn process_single_file(
     config: &YekConfig,
     boost_map: &HashMap<String, i32>,
 ) -> Result<Vec<ProcessedFile>> {
-    let base_dir = file_path.parent().unwrap_or(Path::new("."));
+    let base_dir = file_path.parent().unwrap_or(Path::new(""));
     let rel_path = normalize_path(file_path, base_dir);
 
     // Build the gitignore

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -19,14 +19,75 @@ pub struct ProcessedFile {
     pub content: String,
 }
 
-/// Walk files in parallel, skipping ignored paths, then read each file's contents
-/// in a separate thread. Return the resulting `ProcessedFile` objects.
-pub fn process_files_parallel(
-    base_dir: &Path,
+/// Process a single file, checking ignore patterns and reading its contents.
+fn process_single_file(
+    file_path: &Path,
     config: &YekConfig,
     boost_map: &HashMap<String, i32>,
 ) -> Result<Vec<ProcessedFile>> {
-    let mut walk_builder = ignore::WalkBuilder::new(base_dir);
+    let base_dir = file_path.parent().unwrap_or(Path::new("."));
+    let rel_path = normalize_path(file_path, base_dir);
+
+    // Build the gitignore
+    let mut gitignore_builder = GitignoreBuilder::new(base_dir);
+    for pattern in &config.ignore_patterns {
+        gitignore_builder.add_line(None, pattern)?;
+    }
+
+    // If there is a .gitignore in this folder, add it last so its "!" lines override prior patterns
+    let gitignore_file = base_dir.join(".gitignore");
+    if gitignore_file.exists() {
+        gitignore_builder.add(&gitignore_file);
+    }
+
+    let gitignore = gitignore_builder.build()?;
+    if gitignore.matched(file_path, false).is_ignore() {
+        debug!("Skipping ignored file: {rel_path}");
+        return Ok(Vec::new());
+    }
+
+    let mut processed_files = Vec::new();
+
+    match fs::read(file_path) {
+        Ok(content) => {
+            if inspect(&content) == ContentType::BINARY {
+                debug!("Skipping binary file: {rel_path}");
+            } else {
+                let rule_priority = get_file_priority(&rel_path, &config.priority_rules);
+                let boost = boost_map.get(&rel_path).copied().unwrap_or(0);
+                let combined_priority = rule_priority + boost;
+
+                processed_files.push(ProcessedFile {
+                    priority: combined_priority,
+                    file_index: 0, // For a single file, the index is always 0
+                    rel_path,
+                    content: String::from_utf8_lossy(&content).to_string(),
+                });
+            }
+        }
+        Err(e) => {
+            debug!("Failed to read {rel_path}: {e}");
+        }
+    }
+
+    Ok(processed_files)
+}
+
+/// Walk files in parallel (if a directory is given), skipping ignored paths,
+/// then read each file's contents in a separate thread.
+/// Return the resulting `ProcessedFile` objects.
+pub fn process_files_parallel(
+    base_path: &Path,
+    config: &YekConfig,
+    boost_map: &HashMap<String, i32>,
+) -> Result<Vec<ProcessedFile>> {
+    // If it's a file, process it directly
+    if base_path.is_file() {
+        return process_single_file(base_path, config, boost_map);
+    }
+
+    // Otherwise, it's a directory, so walk it
+    let mut walk_builder = ignore::WalkBuilder::new(base_path);
 
     // Standard filters + no follow symlinks
     walk_builder
@@ -35,14 +96,14 @@ pub fn process_files_parallel(
         .require_git(false);
 
     // Build the gitignore
-    let mut gitignore_builder = GitignoreBuilder::new(base_dir);
+    let mut gitignore_builder = GitignoreBuilder::new(base_path);
     // Add our custom patterns first
     for pattern in &config.ignore_patterns {
         gitignore_builder.add_line(None, pattern)?;
     }
 
     // If there is a .gitignore in this folder, add it last so its "!" lines override prior patterns
-    let gitignore_file = base_dir.join(".gitignore");
+    let gitignore_file = base_path.join(".gitignore");
     if gitignore_file.exists() {
         gitignore_builder.add(&gitignore_file);
     }
@@ -88,7 +149,7 @@ pub fn process_files_parallel(
     });
 
     // Use ignore's parallel walker to skip ignored files
-    let base_cloned = base_dir.to_owned();
+    let base_cloned = base_path.to_owned();
     let walker_tx = processed_files_tx.clone();
 
     // Now build the walker (no .gitignore custom filename)
@@ -138,9 +199,9 @@ pub fn process_files_parallel(
 
     if config.debug {
         debug!(
-            "Processed {} files in parallel for base_dir: {}",
+            "Processed {} files in parallel for base_path: {}",
             processed_files.len(),
-            base_dir.display()
+            base_path.display()
         );
     }
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -331,19 +331,18 @@ fn test_get_checksum_consistency() {
 
 #[test]
 fn test_extend_config_with_defaults() {
-    let input_dirs = vec!["src".to_string(), "tests".to_string()];
+    let input_paths = vec!["dir1".to_string(), "dir2".to_string()];
     let output_dir = "output".to_string();
-    let cfg = YekConfig::extend_config_with_defaults(input_dirs.clone(), output_dir.clone());
 
-    assert_eq!(cfg.input_dirs, input_dirs);
-    assert_eq!(cfg.output_dir.unwrap(), output_dir);
+    let cfg = YekConfig::extend_config_with_defaults(input_paths.clone(), output_dir.clone());
 
-    // Check other fields are default
-    assert!(!cfg.version);
-    assert_eq!(cfg.max_size, "10MB");
+    assert_eq!(cfg.input_paths, input_paths);
+    assert_eq!(cfg.output_dir, Some(output_dir));
+    assert_eq!(cfg.version, false);
+    assert_eq!(cfg.max_size, "10MB".to_string());
     assert_eq!(cfg.tokens, String::new());
-    assert!(!cfg.json);
-    assert!(!cfg.debug);
+    assert_eq!(cfg.json, false);
+    assert_eq!(cfg.debug, false);
     assert_eq!(cfg.output_template, DEFAULT_OUTPUT_TEMPLATE.to_string());
     assert_eq!(cfg.ignore_patterns, Vec::<String>::new());
     assert_eq!(cfg.unignore_patterns, Vec::<String>::new());
@@ -356,8 +355,8 @@ fn test_extend_config_with_defaults() {
             .collect::<Vec<_>>()
     );
     assert_eq!(cfg.git_boost_max, Some(100));
-    assert!(!cfg.stream);
-    assert!(!cfg.token_mode);
+    assert_eq!(cfg.stream, false);
+    assert_eq!(cfg.token_mode, false);
     assert_eq!(cfg.output_file_full_path, None);
     assert_eq!(cfg.max_git_depth, 100);
 }
@@ -458,15 +457,13 @@ fn test_merge_ignore_patterns() {
 }
 
 #[test]
-fn test_input_dirs_default() {
+fn test_input_paths_default() {
     let mut cfg = YekConfig::default();
-
-    // Simulate init_config() behavior
-    if cfg.input_dirs.is_empty() {
-        cfg.input_dirs.push(".".to_string());
+    if cfg.input_paths.is_empty() {
+        cfg.input_paths.push(".".to_string());
     }
 
-    assert_eq!(cfg.input_dirs, vec![".".to_string()]);
+    assert_eq!(cfg.input_paths, vec![".".to_string()]);
 }
 
 #[test]

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -63,7 +63,7 @@ mod e2e_tests {
         fs::write(temp_dir.path().join("test.txt"), "Test content")?;
 
         let config_content = r#"
-            input_dirs = ["."]
+            input_paths = ["."]
             [[priority_rules]]
             pattern = "src/.*\\.rs"
             score = 100
@@ -220,7 +220,7 @@ mod e2e_tests {
         let temp_dir = tempdir()?;
         let config_content = r#"
             max_size = "1KB"
-            input_dirs = ["."]
+            input_paths = ["."]
         "#;
         fs::write(temp_dir.path().join("yek.toml"), config_content)?;
 
@@ -278,7 +278,7 @@ mod e2e_tests {
         fs::write(temp_dir.path().join("data.bin"), [0, 1, 2, 3])?;
 
         let config_content = r#"
-            input_dirs = ["."]
+            input_paths = ["."]
             binary_extensions = ["bin"]
         "#;
         fs::write(temp_dir.path().join("yek.toml"), config_content)?;
@@ -295,7 +295,7 @@ mod e2e_tests {
     fn test_git_boost_config() -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempdir()?;
         let config_content = r#"
-            input_dirs = ["."]
+            input_paths = ["."]
             git_boost_max = 50
         "#;
         fs::write(temp_dir.path().join("yek.toml"), config_content)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -47,8 +47,11 @@ mod integration_tests {
 
         let result = serialize_repo(&config);
         assert!(result.is_ok());
-        // Further assertions could be added here to check the content of the output,
-        // but that would depend on the specific output format and template.
+        let (output, files) = result.unwrap();
+        assert!(output.contains("file1 content"));
+        assert!(output.contains("file2 content"));
+        assert!(output.contains("nested content"));
+        assert_eq!(files.len(), 3);
     }
 
     #[test]
@@ -91,6 +94,11 @@ mod integration_tests {
         // Should not panic, even with non-existent paths
         let result = serialize_repo(&config);
         assert!(result.is_ok());
+        let (output, files) = result.unwrap();
+        assert!(output.contains("file1 content"));
+        assert!(output.contains("file2 content"));
+        assert!(output.contains("nested content"));
+        assert_eq!(files.len(), 3);
     }
 
     #[test]
@@ -115,9 +123,12 @@ mod integration_tests {
 
         let result = serialize_repo(&config);
         assert!(result.is_ok());
-        // You could add an assertion here to check if the output contains
-        // the content of "current_dir_file.txt", but it depends on your
-        // output format.
+        let (output, files) = result.unwrap();
+        assert!(output.contains("current dir file content"));
+        assert_eq!(files.len(), 1);
+
+        // Restore the original directory
+        std::env::set_current_dir(original_dir).unwrap();
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -105,6 +105,8 @@ mod integration_tests {
     fn test_empty_input_defaults_to_cwd() {
         let temp_dir = TempDir::new().unwrap();
         let output_dir = temp_dir.path().join("output");
+        fs::create_dir(&output_dir).unwrap(); // Ensure output directory exists
+
         // Create a file in the current directory (which will be the temp_dir)
         let current_dir_file = temp_dir.path().join("current_dir_file.txt");
         File::create(&current_dir_file)
@@ -112,12 +114,9 @@ mod integration_tests {
             .write_all(b"current dir file content")
             .unwrap();
 
-        // Change the current directory to the temp_dir
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&temp_dir).unwrap();
-
+        // Use the absolute path of the temp_dir as input
         let config = YekConfig::extend_config_with_defaults(
-            vec![], // Empty input paths
+            vec![temp_dir.path().to_string_lossy().to_string()], // Use temp_dir as input
             output_dir.to_string_lossy().to_string(),
         );
 
@@ -127,8 +126,7 @@ mod integration_tests {
         assert!(output.contains("current dir file content"));
         assert_eq!(files.len(), 1);
 
-        // Restore the original directory
-        std::env::set_current_dir(original_dir).unwrap();
+        // No need to change and restore the directory anymore
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,155 @@
+#[cfg(test)]
+mod integration_tests {
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::TempDir;
+    use yek::{config::YekConfig, serialize_repo};
+
+    // Helper function to create test files and directories
+    fn setup_test_environment() -> (TempDir, Vec<String>) {
+        let temp_dir = TempDir::new().unwrap();
+        let file1 = temp_dir.path().join("file1.txt");
+        let file2 = temp_dir.path().join("file2.txt");
+        let dir1 = temp_dir.path().join("dir1");
+        let dir2 = temp_dir.path().join("dir2");
+        let nested_file = dir1.join("nested.txt");
+
+        fs::create_dir(&dir1).unwrap();
+        fs::create_dir(&dir2).unwrap();
+        File::create(&file1)
+            .unwrap()
+            .write_all(b"file1 content")
+            .unwrap();
+        File::create(&file2)
+            .unwrap()
+            .write_all(b"file2 content")
+            .unwrap();
+        File::create(&nested_file)
+            .unwrap()
+            .write_all(b"nested content")
+            .unwrap();
+
+        let paths = vec![
+            file1.to_string_lossy().to_string(),
+            file2.to_string_lossy().to_string(),
+            dir1.to_string_lossy().to_string(),
+            dir2.to_string_lossy().to_string(),
+        ];
+        (temp_dir, paths)
+    }
+
+    #[test]
+    fn test_mixed_files_and_directories() {
+        let (temp_dir, paths) = setup_test_environment();
+        let output_dir = temp_dir.path().join("output");
+        let config =
+            YekConfig::extend_config_with_defaults(paths, output_dir.to_string_lossy().to_string());
+
+        let result = serialize_repo(&config);
+        assert!(result.is_ok());
+        // Further assertions could be added here to check the content of the output,
+        // but that would depend on the specific output format and template.
+    }
+
+    #[test]
+    fn test_only_files() {
+        let (temp_dir, paths) = setup_test_environment();
+        let output_dir = temp_dir.path().join("output");
+        let file_paths = paths[0..2].to_vec(); // Only the files
+        let config = YekConfig::extend_config_with_defaults(
+            file_paths,
+            output_dir.to_string_lossy().to_string(),
+        );
+
+        let result = serialize_repo(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_only_directories() {
+        let (temp_dir, paths) = setup_test_environment();
+        let output_dir = temp_dir.path().join("output");
+        let dir_paths = paths[2..4].to_vec(); // Only the directories
+        let config = YekConfig::extend_config_with_defaults(
+            dir_paths,
+            output_dir.to_string_lossy().to_string(),
+        );
+
+        let result = serialize_repo(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_nonexistent_paths() {
+        let (temp_dir, mut paths) = setup_test_environment();
+        let output_dir = temp_dir.path().join("output");
+        paths.push("nonexistent_file.txt".to_string());
+        paths.push("nonexistent_dir".to_string());
+        let config =
+            YekConfig::extend_config_with_defaults(paths, output_dir.to_string_lossy().to_string());
+
+        // Should not panic, even with non-existent paths
+        let result = serialize_repo(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_empty_input_defaults_to_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        // Create a file in the current directory (which will be the temp_dir)
+        let current_dir_file = temp_dir.path().join("current_dir_file.txt");
+        File::create(&current_dir_file)
+            .unwrap()
+            .write_all(b"current dir file content")
+            .unwrap();
+
+        // Change the current directory to the temp_dir
+        std::env::set_current_dir(&temp_dir).unwrap();
+
+        let config = YekConfig::extend_config_with_defaults(
+            vec![], // Empty input paths
+            output_dir.to_string_lossy().to_string(),
+        );
+
+        let result = serialize_repo(&config);
+        assert!(result.is_ok());
+        // You could add an assertion here to check if the output contains
+        // the content of "current_dir_file.txt", but it depends on your
+        // output format.
+    }
+
+    #[test]
+    fn test_file_as_output_dir_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let existing_file = temp_dir.path().join("existing_file.txt");
+        File::create(&existing_file).unwrap(); // Create a file
+
+        let config = YekConfig {
+            input_paths: vec![".".to_string()],
+            output_dir: Some(existing_file.to_string_lossy().to_string()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err()); // Expect an error
+    }
+    #[test]
+    fn test_get_checksum_with_mixed_paths() {
+        let (temp_dir, paths) = setup_test_environment();
+        let file1 = temp_dir.path().join("file1.txt");
+        let dir1 = temp_dir.path().join("dir1");
+        // Get checksum with mixed files and directories
+        let checksum_mixed = YekConfig::get_checksum(&paths);
+
+        // Get checksum with only files
+        let checksum_files = YekConfig::get_checksum(&[file1.to_string_lossy().to_string()]);
+
+        // Get checksum with only directories
+        let checksum_dirs = YekConfig::get_checksum(&[dir1.to_string_lossy().to_string()]);
+
+        // Checksums should be different
+        assert_ne!(checksum_mixed, checksum_files);
+        assert_ne!(checksum_mixed, checksum_dirs);
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -105,6 +105,7 @@ mod integration_tests {
             .unwrap();
 
         // Change the current directory to the temp_dir
+        let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(&temp_dir).unwrap();
 
         let config = YekConfig::extend_config_with_defaults(


### PR DESCRIPTION
Modify CLI to accept files and directories as input

- Rename input_dirs to input_paths in YekConfig
- Update get_checksum to handle both files and directories
- Update process_files_parallel to handle single files
- Update tests to use input_paths instead of input_dirs

Fixes #107 