### PR TITLE
add `--xml` output support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_derive = "1.0"
 serde_json = "1.0.139"
 serde_yaml = "0.9.34"
 sha2 = "0.10"
-time = "0.3"
+time = "=0.3.34"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_derive = "1.0"
 serde_json = "1.0.139"
 serde_yaml = "0.9.34"
 sha2 = "0.10"
-time = "=0.3.34"
+time = "=0.3"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,3 +351,22 @@ impl YekConfig {
         Ok(())
     }
 }
+
+pub fn validate_config(config: &YekConfig) -> Result<()> {
+    // Validate max_size format
+    if !config.max_size.ends_with('B')
+        && !config.max_size.ends_with('K')
+        && !config.max_size.ends_with('M')
+        && !config.max_size.ends_with('G')
+        && config.tokens.is_none()
+    {
+        bail!("Invalid max_size format. Must end with B, K, M, or G");
+    }
+
+    // Validate that XML and JSON are not both enabled
+    if config.xml && config.json {
+        bail!("Cannot enable both XML and JSON output formats");
+    }
+
+    // ... rest of validation code ...
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,10 @@ pub struct YekConfig {
     #[config_arg()]
     pub json: bool,
 
+    /// Enable XML output
+    #[config_arg()]
+    pub xml: bool,
+
     /// Enable debug output
     #[config_arg()]
     pub debug: bool,
@@ -97,6 +101,7 @@ impl Default for YekConfig {
             max_size: "10MB".to_string(),
             tokens: String::new(),
             json: false,
+            xml: false,
             debug: false,
             output_dir: None,
             output_template: DEFAULT_OUTPUT_TEMPLATE.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use bytesize::ByteSize;
 use clap_config_file::ClapConfigFile;
 use sha2::{Digest, Sha256};
@@ -348,6 +348,21 @@ impl YekConfig {
             })?;
         }
 
+        // Validate max_size format
+        if !self.max_size.ends_with('B')
+            && !self.max_size.ends_with('K')
+            && !self.max_size.ends_with('M')
+            && !self.max_size.ends_with('G')
+            && !self.token_mode
+        {
+            bail!("Invalid max_size format. Must end with B, K, M, or G");
+        }
+
+        // Validate that XML and JSON are not both enabled
+        if self.xml && self.json {
+            bail!("Cannot enable both XML and JSON output formats");
+        }
+
         Ok(())
     }
 }
@@ -358,7 +373,7 @@ pub fn validate_config(config: &YekConfig) -> Result<()> {
         && !config.max_size.ends_with('K')
         && !config.max_size.ends_with('M')
         && !config.max_size.ends_with('G')
-        && config.tokens.is_none()
+        && !config.token_mode
     {
         bail!("Invalid max_size format. Must end with B, K, M, or G");
     }
@@ -368,5 +383,5 @@ pub fn validate_config(config: &YekConfig) -> Result<()> {
         bail!("Cannot enable both XML and JSON output formats");
     }
 
-    // ... rest of validation code ...
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
             xml.push_str(&format_file_as_xml(&file.rel_path, &file.content));
         }
         xml.push_str("</files>");
-        xml
+        Ok(xml)
     } else {
         // Use the user-defined template
         Ok(files_to_include
@@ -195,12 +195,14 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
     }
 }
 
-fn format_file_as_xml(rel_path: &str, content: &str) -> String {
+/// Format a file as XML with the given path and content
+pub fn format_file_as_xml(rel_path: &str, content: &str) -> String {
     let file_name = Path::new(rel_path)
         .file_name()
         .unwrap_or_default()
         .to_string_lossy()
-        .replace(".", "_");
+        .replace(".", "_")
+        .replace(" ", "_");
     format!(
         "<{} path=\"{}\">\n{}\n</{}>\n",
         file_name, rel_path, content, file_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rayon::join;
 use std::path::Path;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
-use yek::{config::YekConfig, serialize_repo};
+use yek::{config::{validate_config, YekConfig}, serialize_repo};
 
 fn main() -> Result<()> {
     // 1) Parse CLI + config files:

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,12 @@ fn main() -> Result<()> {
     // 1) Parse CLI + config files:
     let mut full_config = YekConfig::init_config();
 
+    // Validate that XML and JSON are not both enabled
+    if full_config.xml && full_config.json {
+        eprintln!("Error: Cannot use both --xml and --json flags together");
+        std::process::exit(1);
+    }
+
     let env_filter = if full_config.debug {
         "yek=debug,ignore=off"
     } else {
@@ -61,7 +67,13 @@ fn main() -> Result<()> {
         let checksum = checksum_res;
 
         // Now set the final output file with the computed checksum
-        let extension = if full_config.json { "json" } else { "txt" };
+        let extension = if full_config.json {
+            "json"
+        } else if full_config.xml {
+            "xml"
+        } else {
+            "txt"
+        };
         let output_dir = full_config.output_dir.as_ref().ok_or_else(|| {
             anyhow::anyhow!("Output directory is required when not in streaming mode. This may indicate a configuration validation error.")
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,8 @@ fn main() -> Result<()> {
     // 1) Parse CLI + config files:
     let mut full_config = YekConfig::init_config();
 
-    // Validate that XML and JSON are not both enabled
-    if full_config.xml && full_config.json {
-        eprintln!("Error: Cannot use both --xml and --json flags together");
-        std::process::exit(1);
-    }
+    // Validate config
+    validate_config(&full_config)?;
 
     let env_filter = if full_config.debug {
         "yek=debug,ignore=off"

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -560,3 +560,37 @@ fn test_is_text_file_with_binary_content() {
         "Expected a binary file to be detected as binary"
     );
 }
+
+#[test]
+fn test_validate_xml_json_conflict() {
+    let config = YekConfig {
+        xml: true,
+        json: true,
+        ..Default::default()
+    };
+    let result = config.validate();
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Cannot enable both XML and JSON"));
+}
+
+#[test]
+fn test_validate_xml_only() {
+    let config = YekConfig {
+        xml: true,
+        json: false,
+        ..Default::default()
+    };
+    let result = config.validate();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_json_only() {
+    let config = YekConfig {
+        xml: false,
+        json: true,
+        ..Default::default()
+    };
+    let result = config.validate();
+    assert!(result.is_ok());
+}

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -9,7 +9,7 @@ mod lib_tests {
 
     use yek::{
         concat_files, config::YekConfig, count_tokens, is_text_file, parallel::ProcessedFile,
-        parse_token_limit, priority::PriorityRule, serialize_repo,
+        parse_token_limit, priority::PriorityRule, serialize_repo, format_file_as_xml,
     };
 
     // Initialize tracing subscriber for tests
@@ -685,11 +685,13 @@ mod lib_tests {
                 rel_path: "test.rs".to_string(),
                 content: "fn main() {}".to_string(),
                 priority: 0,
+                file_index: 0,
             },
             ProcessedFile {
                 rel_path: "src/lib.rs".to_string(),
                 content: "pub fn test() {}".to_string(),
                 priority: 1,
+                file_index: 1,
             },
         ];
         let result = concat_files(&files, &config).unwrap();
@@ -710,11 +712,13 @@ mod lib_tests {
                 rel_path: "test.spec.ts".to_string(),
                 content: "test('it works');".to_string(),
                 priority: 0,
+                file_index: 0,
             },
             ProcessedFile {
                 rel_path: "component.test.jsx".to_string(),
                 content: "describe('component');".to_string(),
                 priority: 1,
+                file_index: 1,
             },
         ];
         let result = concat_files(&files, &config).unwrap();
@@ -758,7 +762,7 @@ mod lib_tests {
             file_index: 0,
         }];
         let output = concat_files(&files, &config).unwrap();
-        assert!(output.contains(r#"<test with spaces.txt path="test with spaces.txt">"#));
+        assert!(output.contains(r#"<test_with_spaces_txt path="test with spaces.txt">"#));
         assert!(output.contains("Content with <xml> chars"));
     }
 

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -682,25 +682,56 @@ mod lib_tests {
         };
         let files = vec![
             ProcessedFile {
-                rel_path: "src/test.txt".to_string(),
-                content: "Test content".to_string(),
+                rel_path: "test.rs".to_string(),
+                content: "fn main() {}".to_string(),
                 priority: 0,
-                file_index: 0,
             },
             ProcessedFile {
-                rel_path: "src/nested/file.rs".to_string(),
-                content: "fn main() {}".to_string(),
+                rel_path: "src/lib.rs".to_string(),
+                content: "pub fn test() {}".to_string(),
                 priority: 1,
-                file_index: 1,
             },
         ];
-        let output = concat_files(&files, &config).unwrap();
-        assert!(output.starts_with("<files>\n"));
-        assert!(output.contains(r#"<test.txt path="src/test.txt">"#));
-        assert!(output.contains("Test content"));
-        assert!(output.contains(r#"<file.rs path="src/nested/file.rs">"#));
-        assert!(output.contains("fn main() {}"));
-        assert!(output.ends_with("</files>"));
+        let result = concat_files(&files, &config).unwrap();
+        assert!(result.starts_with("<files>\n"));
+        assert!(result.contains("<test_rs path=\"test.rs\">\n"));
+        assert!(result.contains("<lib_rs path=\"src/lib.rs\">\n"));
+        assert!(result.ends_with("</files>"));
+    }
+
+    #[test]
+    fn test_xml_output_complex_filenames() {
+        let config = YekConfig {
+            xml: true,
+            ..Default::default()
+        };
+        let files = vec![
+            ProcessedFile {
+                rel_path: "test.spec.ts".to_string(),
+                content: "test('it works');".to_string(),
+                priority: 0,
+            },
+            ProcessedFile {
+                rel_path: "component.test.jsx".to_string(),
+                content: "describe('component');".to_string(),
+                priority: 1,
+            },
+        ];
+        let result = concat_files(&files, &config).unwrap();
+        assert!(result.contains("<test_spec_ts path=\"test.spec.ts\">\n"));
+        assert!(result.contains("<component_test_jsx path=\"component.test.jsx\">\n"));
+    }
+
+    #[test]
+    fn test_format_file_as_xml() {
+        let result = format_file_as_xml(
+            "src/test.spec.ts",
+            "describe('test suite');"
+        );
+        assert_eq!(
+            result,
+            "<test_spec_ts path=\"src/test.spec.ts\">\ndescribe('test suite');\n</test_spec_ts>\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
I love yek. Thank you. 

These changes are useful for my purposes, as I have had good success with XML-wrapped prompting. (I think JSON prompts are equally effective, but I construct my prompts in XML and I have a js library I made for converting between xml and hierarchical markdown.)

I am submitting this PR out of courtesy but I'm not hurt at all if there's an intentional choice to only allow JSON and this isn't useful functionality.

While there might be merit for combining the JSON and XML output functionality, I tried to keep this a clean, surgical addition that didn't touch anything in the original code so that I can more easily keep my branch up to date with future versions of yek.

The current tests all pass and there are new tests add for the XML output.