### PR TITLE
Fix release workflow to trigger only on GitHub release creation events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
   release:
@@ -350,7 +349,7 @@ jobs:
     name: Release
     needs: [test, lint, build, should-release]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-release.outputs.yes }} == 'true' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -359,7 +358,7 @@ jobs:
           pattern: build-*
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v2
+        uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: cliff.toml
@@ -367,13 +366,13 @@ jobs:
         env:
           OUTPUT: CHANGES.md
 
-      - name: Create Draft Release
+      - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/build-*/yek-*
           body_path: CHANGES.md
-          tag_name: ${{ needs.should-release.outputs.version }}
-          draft: true
+          tag_name: ${{ github.event.release.tag_name }}
+          draft: false
 
   publish:
     name: Publish to crates.io
@@ -388,7 +387,7 @@ jobs:
       - name: Publish
         run: |
           cargo_version=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
-          if cargo search --color=never yek | grep -q "$cargo_version"; then
+          if cargo info "yek@$cargo_version" 2>/dev/null; then
             echo "yek@$cargo_version already published"
             exit 0
           fi


### PR DESCRIPTION
## Problem
The release workflow was failing for v0.23.0 due to misconfigurations in the CI workflow triggers and job conditions. The workflow was triggering on tag pushes, causing premature runs, and the Release job had incorrect conditions that led to failures.

## Root Cause Analysis
1. **Workflow Triggers**: The workflow was configured to trigger on push to tags ("v*"), which caused the CI to run on tag creation before the release was published.
2. **Release Job Condition**: The Release job condition checked for , but on release events,  is , so the job didn't run as expected.
3. **Docker Build Failure**: The git-cliff-action@v2 used an old Debian buster image with archived repositories, causing Docker build failures.
4. **Publish Check**: The publish job used A-Mazed = "0.1.0"            # App to generate mazes in terminal
A2VConverter = "0.1.1"       # AudioVideoConverter is a Rust library that provides functionality to convert between audio and vid…
ABC-ECS = "0.2.1"            # A simple, fast, and flexible Entity-Component-System library for Rust.
ABC_Game_Engine = "0.1.2"    # A simple, fast, and flexible Game Engine written in Rust, with simplicity in mind.
ABC_lumenpyx = "0.1.0"       # The official ABC-Engine integration for the lumenpyx rendering engine.
ABtree = "0.8.0"             # AVL and Btree for rust
ADA_Standards = "0.3.0"      # A library to help you handle checks on your ADA projects, especially good to build scripts to chec…
ADuCM302x = "0.1.0"          # A Peripheral Access Crate for the Analog Devices ADuCM302x series of MCUs
AJ_find = "0.1.0"            # find the path for a file or directory
AJ_jmp = "0.1.0"             # jump to a directory
... and 196792 crates more (use --limit N to see more) which was unreliable for checking if a version was already published.

## Solution
- Removed the tags trigger from push events to prevent premature workflow runs.
- Updated the Release job to run only on  events.
- Upgraded git-cliff-action to v4 to use a more recent Docker image.
- Changed the publish check to use  for better reliability.
- Set draft to false for immediate release publishing.

## Changes Made
1. Removed  from push triggers.
2. Changed Release job condition to .
3. Updated git-cliff-action from v2 to v4.
4. Changed publish check from A-Mazed = "0.1.0"            # App to generate mazes in terminal
A2VConverter = "0.1.1"       # AudioVideoConverter is a Rust library that provides functionality to convert between audio and vid…
ABC-ECS = "0.2.1"            # A simple, fast, and flexible Entity-Component-System library for Rust.
ABC_Game_Engine = "0.1.2"    # A simple, fast, and flexible Game Engine written in Rust, with simplicity in mind.
ABC_lumenpyx = "0.1.0"       # The official ABC-Engine integration for the lumenpyx rendering engine.
ABtree = "0.8.0"             # AVL and Btree for rust
ADA_Standards = "0.3.0"      # A library to help you handle checks on your ADA projects, especially good to build scripts to chec…
ADuCM302x = "0.1.0"          # A Peripheral Access Crate for the Analog Devices ADuCM302x series of MCUs
AJ_find = "0.1.0"            # find the path for a file or directory
AJ_jmp = "0.1.0"             # jump to a directory
... and 196792 crates more (use --limit N to see more) to .
5. Set  in the release creation step.

## Verification Steps
1. Create a new release on GitHub (e.g., v0.24.0).
2. Verify that the workflow runs only on release creation, not on tag push.
3. Check that the Release job executes successfully and uploads artifacts.
4. Confirm that the publish job publishes to crates.io without errors.
5. Ensure no workflow runs occur on tag pushes to main branch.

## Testing
- The workflow should not trigger on tag pushes.
- On release creation, all jobs should pass.
- Artifacts should be uploaded to the release.
- Package should be published to crates.io.