### PR TITLE
Outline mode: structural skeletons to fit more repo per context budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Clippy
         run: cargo clippy -- -D warnings
+      - name: Clippy (outline feature)
+        run: cargo clippy --features outline -- -D warnings
       - name: Format check
         run: cargo fmt --check
 
@@ -106,6 +108,8 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+      - name: Run tests (outline feature)
+        run: cargo test --features outline --verbose
 
   build:
     name: Build ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2929,6 +2930,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -3389,6 +3396,36 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.5",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -4055,6 +4092,8 @@ dependencies = [
  "toml 0.8.20",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-rust",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ readme = "README.md"
 keywords = ["git", "repository", "serialization", "text", "chunks"]
 categories = ["command-line-utilities", "development-tools"]
 
+[features]
+default = []
+# Structural outline mode. Opt-in: pulls in tree-sitter grammars (C code), so it
+# is off by default to keep the standard build slim and language-agnostic.
+outline = ["dep:tree-sitter", "dep:tree-sitter-rust"]
+
 [dependencies]
 anyhow = "1.0"
 atty = "0.2.14"
@@ -40,6 +46,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 walkdir = "2.4"
 tiktoken-rs = "0.6.0"
+
+# Outline mode (optional; enabled by the `outline` feature).
+tree-sitter = { version = "0.25", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -153,8 +153,40 @@ Options:
       --output-template <OUTPUT_TEMPLATE>         [default: ">>>> FILE_PATH\nFILE_CONTENT"]
       --ignore-patterns <IGNORE_PATTERNS>...
       --unignore-patterns <UNIGNORE_PATTERNS>...
+      --outline                                   Shorthand for --outline-mode always
+      --outline-mode <OUTLINE_MODE>               off | always | degrade [default: off]
+      --outline-level <OUTLINE_LEVEL>             outline | api | symbols [default: outline]
+      --outline-languages <OUTLINE_LANGUAGES>...
+      --outline-fallback <OUTLINE_FALLBACK>       full | omit [default: full]
   -h, --help                                      Print help
 ```
+
+### Outline mode (experimental)
+
+Outline mode replaces file contents with a compact structural **skeleton** —
+imports, type and function signatures, with bodies elided — so far more of a
+repository fits in a fixed context budget. It is built on tree-sitter and is
+**opt-in behind the `outline` Cargo feature** (so the default build stays slim
+and language-agnostic). Currently supported: **Rust** (more languages planned).
+
+```bash
+# Emit a structural map of the whole repo
+yek --outline
+
+# Choose how much detail: outline (default), api (public only), or symbols
+yek --outline-mode always --outline-level symbols
+
+# Budget-aware: keep the most important files full, outline the rest to fit
+yek --outline-mode degrade --tokens 128k
+```
+
+Files in unsupported languages keep their full content (`--outline-fallback
+full`, the default) or are dropped (`--outline-fallback omit`). Abbreviated files
+are marked with `⟪yek:LEVEL⟫` in text output, and `--json` adds a `"level"`
+field. All of these can also be set in `yek.yaml` (`outline_mode`,
+`outline_level`, `outline_languages`, `outline_fallback`).
+
+> Build with outline support: `cargo install --path . --features outline`.
 
 ## Configuration File
 

--- a/docs/outline-plan.md
+++ b/docs/outline-plan.md
@@ -228,6 +228,10 @@ the existing rayon/threaded walk in `parallel.rs` with no architectural change.
 
 3. `concat_files` is replaced/extended by the **degradation allocator** (§9).
 
+> Refined in §15.3/§15.6: store `Option<Vec<Symbol>>` (parse once, byte ranges,
+> no string copies) and render the *chosen* level lazily, rather than caching
+> three rendered strings per file — a memory and token-counting win.
+
 This keeps the hot path for the default (outline-off) build byte-for-byte
 identical to today.
 
@@ -302,21 +306,33 @@ outline for the rest"** — include full content top-down until the budget is, s
 60% spent, then switch every remaining file to outline, then to symbols, then
 stop. Ship that first; generalize to the upgrade loop in Phase 3.
 
+> The production allocator — single-pass suffix-floor, lazy/memoized token
+> counting, and the "even the skeleton won't fit" global fallback — is specified
+> with perf bounds in §15.7. The seed-then-upgrade sketch above recomputes costs
+> repeatedly; §15.7 avoids that.
+
 ## 10. Output format
 
 So the model (and humans) can tell a file was abbreviated, annotate the template
 context. Add an optional `LEVEL` placeholder and a default suffix marker:
 
 ```text
->>>> src/parallel.rs (outline)
+>>>> src/parallel.rs
+⟪outline: bodies elided⟫
 …signatures…
 ```
 
-- Default template stays `>>>> FILE_PATH\nFILE_CONTENT`; when a file is rendered
-  below L0, `FILE_PATH` is suffixed with ` (outline)` / ` (api)` / ` (symbols)`,
-  or a new `LEVEL` token is exposed for custom templates.
-- `--json` output gains a `"level": "outline"` field per object so programmatic
-  consumers (and an MCP server) can distinguish abbreviated entries.
+- Default template stays `>>>> FILE_PATH\nFILE_CONTENT`, and **`FILE_PATH` is
+  never mutated** — suffixing it (e.g. `(outline)`) would break round-tripping
+  (`unyek`, issue #64) and any path-keyed consumer. Instead, expose a new
+  `LEVEL` placeholder that expands to `""` for full files and ` (outline)` etc.
+  for abbreviated ones, opt-in via custom templates (see §15.9).
+- For LLM legibility, abbreviated files get an in-block hint line
+  (`⟪outline: bodies elided⟫`) so the model knows the content is partial without
+  inspecting the header.
+- `--json` output gains a `"level": "full|outline|api|symbols|index"` field per
+  object so programmatic consumers (and an MCP server) can distinguish
+  abbreviated entries; full files keep today's shape (the field is additive).
 
 ## 11. Performance
 
@@ -374,7 +390,323 @@ broader roadmap.
   `export`, Python `_name` convention, Go capitalization). Encode per-extractor;
   document the heuristic per language.
 
-## 15. Appendix — illustrative before/after
+## 15. Implementation plan (detailed)
+
+This section turns §5–§11 into concrete, perf-bounded engineering work, and folds
+in the gaps found while detailing it (§15.12).
+
+### 15.1 Dependencies, build, and binary-size strategy
+
+Engine = `tree-sitter` + per-language outline queries, **gated behind a Cargo
+feature** so the default build is byte-identical to today.
+
+```toml
+[features]
+default = []
+outline = [
+  "dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript",
+  "dep:tree-sitter-javascript", "dep:tree-sitter-python",
+  "dep:tree-sitter-go", "dep:tree-sitter-java",
+]
+
+[dependencies]
+tree-sitter      = { version = "0.24", optional = true }   # representative; pin a tested set
+tree-sitter-rust = { version = "0.23", optional = true }
+# … one optional dep per grammar …
+```
+
+Hard rules (each closes a gap):
+
+- **ABI pinning.** Core and every grammar must agree on the tree-sitter language
+  ABI. Pin an exact, tested set; prefer grammar crates that depend on the
+  lightweight `tree-sitter-language` shim (decouples them from a specific core
+  version). A CI job builds `--features outline` and smoke-parses one fixture per
+  language so an ABI bump fails loudly instead of at runtime.
+- **C toolchain on every release target.** Grammars compile C via `cc`. yek's
+  release matrix (Build/Stress per target: apple-darwin aarch64/x86, linux
+  gnu/**musl**, **windows-msvc**) all have a C compiler on GH runners and in
+  `cross` images — but musl and msvc grammar builds must be verified in CI before
+  the feature is enabled on prebuilt artifacts.
+- **Binary size / compile time.** Each grammar adds ~0.5–2 MB and C compile time;
+  with the existing `lto = true` + `strip = true` profile the 5-language set is a
+  few MB. Keep the feature **off by default**; decide separately whether prebuilt
+  release binaries ship it on (recommended: yes for prebuilt, off for the
+  crates.io default so `cargo install yek` stays slim).
+- **`panic = "abort"`.** Extraction must never panic — every tree-sitter call
+  returns `Option`/`Result` and falls back to L0.
+
+Built **without** the feature, any `--outline-mode` other than `off` prints a
+one-line stderr warning and proceeds as `off` (no hard error → scripts stay
+portable).
+
+### 15.2 Module layout
+
+```
+src/outline/
+  mod.rs        # public API: detect_language, extract, render, OutlineLevel, Symbol
+  lang.rs       # Language enum, extension→Language, per-language LanguageConfig (data)
+  registry.rs   # OnceLock registry of CompiledLanguage (holds the compiled Query)
+  extract.rs    # parse-once → Vec<Symbol> (ranges only, no copies)
+  render.rs     # render-at-level (slices content by range), elision, nesting
+  queries/      # rust.scm typescript.scm javascript.scm python.scm go.scm java.scm
+```
+
+`.scm` files are `include_str!`-embedded (zero runtime file IO).
+
+### 15.3 Core types
+
+```rust
+pub enum OutlineLevel { Full, Outline, Api, Symbols }   // Omit handled by allocator
+
+pub enum SymbolKind { Module, Import, Class, Struct, Enum, Trait, Interface,
+                      Function, Method, Type, Const, Field, Macro, Other }
+
+pub struct Symbol {
+    kind: SymbolKind,
+    is_public: bool,
+    name_range: Range<usize>,    // byte ranges INTO ProcessedFile.content — no String copies
+    sig_range: Range<usize>,     // decl start .. body open (whole decl if bodyless)
+    doc_range: Option<Range<usize>>,
+    body_open: Option<usize>,    // byte offset where body starts (None ⇒ no body to elide)
+    start_row: usize, end_row: usize,   // for the "… N lines …" marker (free from nodes)
+    depth: u16,                  // nesting depth → indentation
+    children: Vec<u32>,          // indices into this file's symbol vec (a tree)
+}
+```
+
+Storing **ranges, not strings** is the key memory decision: file content already
+lives in `ProcessedFile.content`, so every level renders by slicing it. Per-file
+overhead is one small `Vec<Symbol>`.
+
+### 15.4 Extraction (parse once per file)
+
+A single, data-driven code path. Each language ships one `.scm` using a uniform
+capture protocol:
+
+| Capture | Meaning |
+| --- | --- |
+| `@item` | the whole declaration node |
+| `@item.name` | identifier to display |
+| `@item.body` | body node to elide (absent ⇒ no body, e.g. a type alias) |
+| `@item.doc` | leading doc-comment node(s) |
+
+`SymbolKind` is fixed by *which* pattern matched; `is_public` comes from a
+per-language rule (this is the gap "visibility differs per language"):
+
+```rust
+enum VisibilityRule {
+    Marker(&'static str),  // Rust: child node kind "visibility_modifier"
+    Exported,              // JS/TS: nearest ancestor is export_statement
+    Capitalized,           // Go: identifier starts uppercase
+    Underscore,            // Python: name does not start with '_'
+    AlwaysPublic,
+}
+```
+
+Algorithm (`extract.rs`), per file, on a worker thread:
+
+1. Look up `CompiledLanguage` from the registry (`OnceLock`; query compiled once).
+2. Thread-local `Parser` (set language once per thread); `parse(content.as_bytes(), None)`.
+3. If a high fraction of bytes are under `ERROR` nodes ⇒ return `None` (caller
+   keeps L0). A few `ERROR` nodes are tolerated.
+4. Run the outline `Query` with a **reused** `QueryCursor`; collect flat `Symbol`s.
+5. Rebuild nesting: sort by `sig_range.start`, push/pop a stack by end-byte
+   containment to set `depth`/`children`.
+6. Guard rails: cap at `MAX_SYMBOLS` (~2000) per file; beyond it keep top-level
+   only and append a synthetic "… +N nested elided".
+7. Empty/near-empty (≤1 trivial symbol) ⇒ return `None` (outline wouldn't save
+   tokens; keeping L0 is strictly better).
+
+Perf: parse is O(bytes) at tree-sitter's MB/s; the `Query` compiles **once per
+language** and is shared (`&Query: Sync`); `QueryCursor` is reused; no source
+text is copied.
+
+### 15.5 Rendering (render the chosen level only)
+
+`render(content, &[Symbol], level) -> String`, slicing `content` by range:
+
+- **Full** — content verbatim.
+- **Outline (L1)** — preorder over the symbol tree, indented by `depth`: emit
+  `@doc` (if any) + `content[sig_range]`; if `body_open` is `Some`, append the
+  language's elision marker carrying the hidden line count
+  (`{ /* … 42 lines … */ }` for brace langs, `: …  # 42 lines` for Python).
+  Container bodies (class/module) are **not** elided — we recurse into members.
+- **Api (L2)** — L1 minus non-public symbols (and their private-only subtrees),
+  and without `@doc`.
+- **Symbols (L3)** — one line per symbol: `kind name (Lstart–Lend)`, indented.
+
+### 15.6 Pipeline integration (parallel, perf-first)
+
+The read path is unchanged. Add **one parallel CPU stage** after files are read
+and before sorting, only when outline is active:
+
+```rust
+// lib.rs::serialize_repo, right after process_files_parallel(...) returns `files`
+#[cfg(feature = "outline")]
+if config.outline_active() {
+    files.par_iter_mut().for_each(|f| {
+        if let Some(lang) = outline::detect_language(&f.rel_path) {
+            f.language = Some(lang);
+            f.symbols  = outline::extract(&f.content, lang); // Option<Vec<Symbol>>
+        }
+    });
+}
+```
+
+Why a separate stage: extraction is CPU-bound and embarrassingly parallel, so it
+wants the full rayon pool. Today's pipeline reads files on a **single** processing
+thread (the channel consumer in `parallel.rs`); parsing there would serialize it.
+`par_iter_mut` over the already-collected, already-in-memory files avoids that
+bottleneck with no extra IO. Parsers are `Send` but not `Sync`, so use a
+thread-local pool:
+
+```rust
+thread_local! { static PARSERS: RefCell<HashMap<Language, Parser>> = /* … */; }
+```
+
+### 15.7 Budget-aware allocator (replaces the `concat_files` cut)
+
+Refines §9 into a **single forward pass with bounded token counting**. Files are
+processed priority-DESC; per-file candidate levels `Full ▸ Outline ▸ Api ▸
+Symbols` (cheapest last); `Omit` is the implicit floor.
+
+```text
+cost(f, L) = token_mode ? count_tokens(format(f, L)) : len(format(f, L))   # memoized per (f,L)
+floor(f)   = cost(f, Symbols)            # cheapest non-omit form of f
+
+# Precompute in parallel (par_iter):
+#   floor(f) for all f
+#   suffix_floor[i] = Σ floor(f) for files i..n      # what the tail still needs
+# If suffix_floor[0] > cap  →  GLOBAL FALLBACK (below).
+
+used = 0
+for i, f in files:                        # priority DESC, sequential
+    budget_here = cap - used - suffix_floor[i+1]    # room that still lets the tail reach its floor
+    pick = Symbols
+    for L in [Api, Outline, Full]:        # try richer; first that doesn't fit stops the climb
+        if cost(f, L) <= budget_here { pick = L } else { break }
+    used += cost(f, pick); assign(f, pick)
+```
+
+Perf properties / gaps closed:
+
+- **Hard cap respected** (token or byte) — every choice is checked against exact
+  `cost`.
+- **Priority-greedy, not knapsack** — *by design*: a high-priority file is never
+  downgraded to fund a lower-priority one. Matches yek's "importance is king"
+  model and is O(n·levels), not NP-hard search.
+- **Bounded tiktoken work.** Exact counts: `floor` for all files (parallel) +
+  `Full` only for files whose `budget_here` could admit it (the long
+  low-priority tail never pays for a `Full` count) + ≤2 intermediate counts for
+  frontier files. Low-priority files cost exactly one count. This is comparable
+  to today's token-mode cost — `Full` counts reuse the same per-file-formatted
+  counting `concat_files` already does — not a 4× blowup.
+- **Byte mode is nearly free** (`len`, no tiktoken).
+- **Template overhead is counted.** `format(f, L)` includes the `>>>> PATH`
+  header, so the per-file header cost is in the budget (it can dominate for many
+  tiny files — see fallback).
+- **GLOBAL FALLBACK** for the maintainer's "even the skeleton won't fit" case:
+  when all-`Symbols` exceeds `cap`, collapse the lowest-priority tail into a
+  **single repo-level compact index** block (one header; `path: symA, symB, …`
+  per line), amortizing the per-file header that otherwise dominates at thousands
+  of files; keep upgrading the high-priority head. A bare **file-tree** (paths
+  only) is the terminal rung before `Omit`.
+- **Debug metrics** (cheap): under `--debug`, log
+  `full M · outline N · api A · symbols K · index/omit J — saved ≈X tokens (Y%)`.
+
+This also corrects the §3 ordering issue: processing priority-DESC means tight
+budgets keep the *most* important files, not drop them.
+
+### 15.8 CLI & config plumbing
+
+`config.rs` gains fields in the existing `#[config_arg]` style:
+
+```rust
+#[config_arg(default_value = "off")]      pub outline_mode: OutlineMode,       // off|always|degrade
+#[config_arg(default_value = "outline")]  pub outline_level: OutlineLevel,     // outline|api|symbols
+#[config_arg(accept_from = "config_only")] pub outline_languages: Vec<String>,
+#[config_arg(default_value = "full")]     pub outline_fallback: OutlineFallback, // full|omit
+```
+
+`--outline` is sugar for `--outline-mode always`. Add a computed
+`outline_active()`. `validate()` rejects unknown language names and, when built
+without the `outline` feature, downgrades non-`off` modes to `off` with a stderr
+warning. All defaults reproduce current behavior.
+
+### 15.9 Output format & round-tripping
+
+Refines §10, closing a correctness gap: **never mutate `FILE_PATH`** (that breaks
+`unyek`/#64 and path-keyed tools). Instead expose a `LEVEL` placeholder
+(`""` for full, ` (outline)`/` (api)`/` (symbols)`/` (index)` otherwise),
+opt-in via custom templates; add an in-block `⟪outline: bodies elided⟫` hint for
+the LLM; add `"level"` to `--json`. Document loudly that non-`full` output is
+**lossy and irreversible** — `unyek` must refuse to reconstruct it.
+
+### 15.10 Testing & CI
+
+- **Golden/snapshot** (add `insta` dev-dep) per language: fixture source → L1/L2/L3.
+- **Fallback**: unsupported extension stays L0 under `always`; `--outline-fallback
+  omit` drops it; high-`ERROR`-ratio source ⇒ L0.
+- **Allocator unit tests** with synthetic known costs: (a) never exceeds cap;
+  (b) monotonic — no lower-priority file ends richer than a higher-priority one;
+  (c) `off` reproduces today's bytes exactly; (d) global-fallback triggers and
+  stays under cap.
+- **Determinism**: stable order + stable markers (snapshot).
+- **Property**: `cost(Symbols) ≤ cost(Api) ≤ cost(Outline) ≤ cost(Full)` per fixture.
+- **CI matrix**: build & test `--no-default-features` (today's path) **and**
+  `--features outline`; smoke-parse each language (ABI guard); verify musl +
+  windows-msvc grammar builds; add a binary-size report step.
+- **Bench**: extend `benches/serialization.rs` with a mixed-language tree
+  measuring (1) extraction wall-clock vs. read time and (2) tokens emitted per
+  mode, to quantify the budget win.
+
+### 15.11 Milestones (file-level)
+
+- **M1 — Scaffold (Rust only).** `Cargo.toml` feature+deps; `src/outline/*` with
+  the Rust query; `config.rs` flags+validation; `lib.rs` parallel extract stage +
+  allocator restricted to `Full/Omit` for `off`-equivalence; `LEVEL` token;
+  fixtures + snapshots; two-config CI build. *Acceptance:* `--outline` on a Rust
+  dir emits signatures; `off` output is byte-for-byte unchanged;
+  `--no-default-features` builds.
+- **M2 — Languages.** TS/JS(+TSX/JSX), Python, Go, Java queries + visibility
+  rules + fixtures; `--outline-languages`, `--outline-fallback`.
+- **M3 — Degradation.** Suffix-floor allocator, `Api`/`Symbols`, global
+  compact-index fallback, `--outline-mode degrade`, debug metrics; allocator +
+  property tests; bench proving reduction. *Acceptance:* tight `--tokens` keeps
+  every file represented under the cap with high-priority files full.
+- **M4 — Custom rules.** User-overridable queries/visibility in `yek.yaml`;
+  document adding a language with no code change.
+- **M5 — Lazy retrieval / MCP.** Outline-first serialization + on-demand
+  symbol/file expansion as MCP tools (issues #245, #232).
+
+### 15.12 Gaps found while detailing, and resolutions
+
+| Gap in the v1 sketch | Resolution |
+| --- | --- |
+| Counting tokens for 4 levels × all files is costly | Parse once → `Vec<Symbol>` (ranges); render lazily; precompute only `floor` (parallel) + `Full` for the head; memoize per (file,level); suffix-floor skips `Full` counts for the tail (§15.7). |
+| Caching 4 rendered strings per file wastes memory | Store ranges only; render the chosen level once at the end (§15.3). |
+| Per-file template header dominates at thousands of tiny files (skeleton still won't fit) | Global compact-index fallback (one header, many files) + bare file-tree rung (§15.7). |
+| Suffixing `FILE_PATH` with `(outline)` breaks round-trip/#64 and path-keyed tools | Separate `LEVEL` placeholder; path stays exact; in-block hint; JSON `level` (§15.9). |
+| Single processing thread would serialize CPU-bound parsing | Dedicated `par_iter_mut` extract stage on the rayon pool (§15.6). |
+| Files with no / huge symbol sets | Empty ⇒ fall back to L0; huge ⇒ `MAX_SYMBOLS` cap with elision (§15.4). |
+| Parse errors / partial files | Tolerate few `ERROR` nodes; high error ratio ⇒ L0 (§15.4). |
+| Grammar/core ABI drift across many release targets | Pin a tested set (prefer `tree-sitter-language` shim) + CI smoke-parse + musl/msvc build checks (§15.1). |
+| Building slim/default without grammars | Cargo feature gate; non-`off` modes warn and act as `off` (§15.1/§15.8). |
+| `from_utf8_lossy` could desync byte ranges | Parse and slice the *same* lossy string ⇒ self-consistent ranges (§15.4). |
+| Nested members (methods in classes) flattened | Stack-based nesting reconstruction → `depth`/`children`, indented render (§15.4/§15.5). |
+
+### 15.13 Performance targets (acceptance guards)
+
+- **Outline OFF:** zero overhead — identical code path and binary as today
+  (feature-gated out); enforced by the byte-identical `off` snapshot test.
+- **Outline ON:** added latency dominated by parse (target ≲ 1× the warm
+  file-read time, run in parallel) plus bounded tiktoken counts (≈ today's
+  token-mode counts + the frontier). Peak memory grows only by `Vec<Symbol>`
+  per file.
+- **Token win:** target the ast-grep-reported **35–55%** reduction on large repos
+  at equal symbol coverage, tracked by the new benchmark.
+
+## 16. Appendix — illustrative before/after
 
 A 1,200-line, 5-file TypeScript service, budget `--tokens 8k`:
 

--- a/docs/outline-plan.md
+++ b/docs/outline-plan.md
@@ -716,3 +716,30 @@ A 1,200-line, 5-file TypeScript service, budget `--tokens 8k`:
   3 collapse to outlines (exports + signatures). All 5 files are represented, the
   budget is respected, and the model has a complete structural map plus full
   detail where it matters most.
+
+## 17. Implementation status
+
+What has shipped so far (behind the `outline` Cargo feature), and where it
+deviates from the design above:
+
+- **Engine (M1):** `src/outline/` with `Full/Outline/Api/Symbols` levels,
+  attribute + doc-comment capture, depth re-indentation, and `MAX_SYMBOLS` /
+  error-ratio guards. **Rust only.**
+- **Extraction approach — deviation:** a **field-based tree walk** driven by a
+  per-language classification table, *not* the `.scm` query protocol of §15.4.
+  It is more robust across tree-sitter/grammar versions and avoids the
+  streaming-iterator query API churn, while staying data-driven. The `.scm`
+  route (and user-overridable rules, M4) remains a future option.
+- **Config/CLI (M1):** `--outline[-mode|-level|-languages|-fallback]` plus the
+  matching `yek.yaml` keys; resolver accessors; feature-off warning.
+- **Pipeline (M1) + degrade (partial M3):** `apply` runs before the budget step.
+  `always` is complete. `degrade` is the **"simpler v1"** from §9 (full for the
+  highest-priority files up to ~half the budget, outline the rest) — *not yet*
+  the single-pass suffix-floor allocator of §15.7, and its cost accounting is
+  approximate (raw content, see `pipeline::cost`). The global compact-index
+  fallback and L2/L3 budget integration are still to come.
+- **Budget fix:** `concat_files` now selects most-important-first (the §3 note),
+  which also makes `degrade` correct.
+- **Not yet started:** more languages (M2), the exact suffix-floor allocator and
+  metrics (rest of M3), user-overridable rules (M4), MCP/lazy-retrieval (M5),
+  and the benchmark/binary-size CI from §15.10.

--- a/docs/outline-plan.md
+++ b/docs/outline-plan.md
@@ -1,0 +1,386 @@
+# Plan: Outline mode — squeeze more of a repo into a context budget
+
+> Status: proposal / design doc
+> Tracking issue: [#245 "Support lazy retrieval"](https://github.com/mohsen1/yek/issues/245) (related: [#232 "MCP for Yek"](https://github.com/mohsen1/yek/issues/232))
+> Inspiration: [ast-grep `outline`](https://ast-grep.github.io/blog/ast-grep-outline.html)
+
+## 1. Summary
+
+Add an **outline mode** to `yek` that emits a structural *skeleton* of source
+files — declarations, signatures, types, imports/exports — with bodies elided,
+instead of (or alongside) full file content. Outlines are far cheaper in tokens
+than full source, so a fixed `--tokens` budget can cover a much larger slice of
+a repository while preserving the "map" an LLM needs to reason about the code.
+
+The headline capability is **budget-aware degradation**: when the repo does not
+fit in the budget, instead of dropping whole files (today's behavior), `yek`
+downgrades the least important files to their outline (and, if needed, to a bare
+symbol index) so the most important files keep full fidelity and everything else
+still contributes structural signal.
+
+ast-grep's own benchmarks for the same idea report **35–55% median token
+reductions** on large repos while keeping 100% symbol coverage. That is the win
+we are chasing.
+
+## 2. Motivation
+
+`yek` exists to pack a repository into an LLM context window. Today it operates
+at **whole-file granularity**: a file is either included verbatim or omitted.
+Under a tight `--tokens` budget that is wasteful — a 2,000-line file might cost
+20k tokens, but its 60 function signatures cost ~800 tokens and still tell the
+model what the file *is*, what it exposes, and where to look next.
+
+The [ast-grep outline post](https://ast-grep.github.io/blog/ast-grep-outline.html)
+frames the same observation: agents waste tokens opening whole files just to
+learn their structure. A compact, syntax-aware "table of contents" (declarations
++ source ranges) lets an agent move from *directory → symbols → targeted slice*
+incrementally, instead of paying for full reads up front.
+
+For `yek` this unlocks two things:
+
+1. **More repo per budget.** Fit the structure of a whole codebase into the same
+   window that previously held a handful of files.
+2. **A foundation for lazy retrieval** (issue #245 / CodeRLM-style): outline
+   first, then fetch full bodies for specific symbols on demand — naturally
+   exposed over MCP (issue #232).
+
+## 3. How `yek` works today (the parts this touches)
+
+```
+init_config (config.rs)
+  └─ serialize_repo (lib.rs)
+       ├─ get_recent_commit_times_git2 / compute_recentness_boost (priority.rs)
+       ├─ process_files_parallel (parallel.rs)
+       │     → walk, skip ignored + binary, read FULL content
+       │     → Vec<ProcessedFile { priority, file_index, rel_path, content }>
+       ├─ sort by (priority asc, rel_path)
+       └─ concat_files (lib.rs)
+             → greedily accumulate until token/byte cap, then stop
+```
+
+Key facts that shape this design:
+
+- **`ProcessedFile.content` is the full file text** (`parallel.rs`). There is no
+  per-file representation other than "the whole thing."
+- **`concat_files` enforces the budget at whole-file granularity** (`lib.rs:111`).
+  It sorts files and includes them until the next file would exceed `cap`, then
+  `break`s. There is no notion of a cheaper representation of a file.
+- **`yek` is intentionally language-agnostic.** `parallel.rs` reads bytes and
+  only distinguishes text vs binary (`content_inspector`). Nothing parses code.
+- The output is rendered through a **template** (`output_template`, default
+  `>>>> FILE_PATH\nFILE_CONTENT`), or JSON when `--json` is set.
+
+> Note: the current allocator iterates in **ascending** priority and `break`s at
+> the first file that overflows, so under a tight budget it can drop the
+> *highest*-priority files (they sort last). The new allocator below processes
+> **most-important-first** and degrades the rest, which also corrects this edge.
+
+## 4. Constraints from the maintainer (issue #245)
+
+The owner already tried this manually and flagged the real risks
+([comment](https://github.com/mohsen1/yek/issues/245#issuecomment-3900331706)):
+
+> "Building project skeleton is something I have tried manually and was
+> successful using ast-grep. need to design it well. sometimes projects are too
+> big that even the skeleton won't fit in context so we should be smart about
+> what is important. Yek is not language specific and this would add 'supported
+> languages' which is a concern."
+
+Three hard constraints fall out of that, and the design is organized around them:
+
+| Concern | Design response |
+| --- | --- |
+| **"Yek is not language specific."** Adding parsers risks changing the project's identity and bloating the default binary. | Outline is **opt-in** and **additive**, gated behind a Cargo feature (`outline`). The default build stays byte-only and language-agnostic. Unsupported languages **gracefully fall back** to existing behavior. |
+| **"Even the skeleton won't fit."** | **Multiple levels of detail** (full → outline → public-API-only → symbol index) plus a **budget-aware degradation allocator** that spends fidelity on high-priority files first. |
+| **"Need to design it well."** | A small, isolated `outline` module with a single trait boundary; per-language extractors are data (queries), not code; everything is tested with fixtures and benchmarked. |
+
+## 5. Core concept: Levels of Detail (LoD)
+
+Define an ordered set of representations for a file, cheapest last:
+
+| Level | Name | What it contains | Rough cost |
+| --- | --- | --- | --- |
+| L0 | `Full` | Verbatim file content (today). | 100% |
+| L1 | `Outline` | Imports/exports, type/class/struct/enum decls, function & method **signatures**, leading doc comments; bodies replaced by an elision marker. | ~10–25% |
+| L2 | `Api` | Same as L1 but **public/exported symbols only** (drop private). | ~5–15% |
+| L3 | `Symbols` | File path + flat list of top-level symbol names (+ line ranges). | ~1–3% |
+| L4 | `Omit` | File dropped entirely (today's only fallback). | 0% |
+
+L2 leans on the visibility/export metadata the ast-grep blog describes
+(extraction rules carry a "public/export" flag). Being able to keep *public API*
+and drop private internals is exactly the "be smart about what's important"
+lever the maintainer asked for.
+
+Example (Rust), L1 outline:
+
+```rust
+>>>> src/parallel.rs (outline)
+use crate::{config::YekConfig, priority::get_file_priority, Result};
+use rayon::prelude::*;
+
+pub struct ProcessedFile {
+    pub priority: i32,
+    pub file_index: usize,
+    pub rel_path: String,
+    pub content: String,
+}
+
+fn process_single_file(file_path: &Path, config: &YekConfig, boost_map: &HashMap<String, i32>) -> Result<Vec<ProcessedFile>> { /* … 51 lines … */ }
+pub fn process_files_parallel(base_path: &Path, config: &YekConfig, boost_map: &HashMap<String, i32>) -> Result<Vec<ProcessedFile>> { /* … 33 lines … */ }
+pub fn normalize_path(path: &Path, base: &Path) -> String { /* … 9 lines … */ }
+```
+
+The elision marker (`/* … N lines … */`, `# … N lines …`, etc.) keeps line
+counts so the model knows how much was hidden and the output stays valid-ish for
+the language.
+
+## 6. Technical approach for extraction
+
+We need to turn source text into an outline per language. Three options:
+
+**Option A — Embed tree-sitter + grammars + `tags.scm` queries (recommended).**
+Tree-sitter already ships community `tags.scm` queries designed for exactly this
+(ctags-style symbol extraction). We embed `tree-sitter` plus a curated set of
+grammar crates and run a tags/outline query per file.
+- ➕ Single static binary, no runtime dependency, fast, matches `yek`'s ethos.
+- ➕ Queries are *data* — adding a language is adding a grammar crate + a `.scm`.
+- ➖ Heavier dependency tree, bigger binary, longer compile (mitigated by the
+  Cargo feature gate so default builds are unaffected).
+
+**Option B — `ast-grep-core` + grammars, with declarative rules.**
+Use ast-grep's Rust crates and ship YAML extraction rules per language (the
+exact mechanism in the blog). Very close to Option A technically; the rules are
+arguably more readable/overridable than `.scm`, and we inherit ast-grep's
+range/metadata model.
+- ➕ User-overridable rules in `yek.yaml` fit `yek`'s config-driven design.
+- ➖ Same binary-size cost; ties us to ast-grep's crate API surface.
+
+**Option C — Shell out to the `ast-grep` CLI `outline` command.**
+- ➕ Least code; reuse a maintained implementation.
+- ➖ Re-introduces an external runtime dependency, breaks single-binary
+  distribution, and adds process-spawn overhead. **Rejected** — it conflicts
+  with `yek`'s "one fast binary" value.
+
+**Recommendation:** Option A as the engine, with Option B's *user-overridable
+rules* idea layered on later (Phase 4). Hide a trait so the engine choice stays
+swappable:
+
+```rust
+// src/outline/mod.rs
+pub enum OutlineLevel { Full, Outline, Api, Symbols, Omit }
+
+pub struct Symbol {
+    pub name: String,
+    pub kind: SymbolKind,      // Function, Method, Class, Struct, Enum, Trait, Type, Const, Import…
+    pub is_public: bool,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub signature: String,     // text from decl start to body open
+}
+
+pub trait OutlineExtractor: Send + Sync {
+    fn language(&self) -> Language;
+    fn symbols(&self, source: &str) -> Vec<Symbol>;
+}
+
+/// Render a file at a given level. Returns None if the language is unsupported,
+/// signalling the caller to fall back to Full content.
+pub fn render(source: &str, lang: Language, level: OutlineLevel) -> Option<String>;
+
+/// Map an extension to a supported language, or None.
+pub fn detect_language(rel_path: &str) -> Option<Language>;
+```
+
+Language detection reuses the extension-driven style already in `defaults.rs`.
+
+### Initial language set (Phase 1–2)
+
+Rust, TypeScript/JavaScript (+ TSX/JSX), Python, Go, Java. These cover the bulk
+of real usage and all have mature tree-sitter grammars and `tags.scm` queries.
+Everything else falls back to L0 (or is configurable).
+
+## 7. Pipeline integration
+
+Outline extraction is **per-file and embarrassingly parallel**, so it slots into
+the existing rayon/threaded walk in `parallel.rs` with no architectural change.
+
+1. `ProcessedFile` gains lazily-computed alternate representations. To avoid
+   parsing when outline is off, keep `content` as-is and add an optional,
+   on-demand outline cache:
+
+   ```rust
+   pub struct ProcessedFile {
+       pub priority: i32,
+       pub file_index: usize,
+       pub rel_path: String,
+       pub content: String,                 // L0, as today
+       pub language: Option<Language>,      // detected once
+       // computed only when outline mode is active:
+       pub outline: Option<String>,         // L1
+       pub api: Option<String>,             // L2
+       pub symbols: Option<String>,         // L3
+   }
+   ```
+
+2. When outline mode is active, the worker that already reads the file also runs
+   the extractor and fills the alternate representations. Parsing only happens
+   for supported languages and only when requested.
+
+3. `concat_files` is replaced/extended by the **degradation allocator** (§9).
+
+This keeps the hot path for the default (outline-off) build byte-for-byte
+identical to today.
+
+## 8. CLI & config surface
+
+```text
+--outline                     Shorthand for --outline-mode always
+--outline-mode <MODE>         off | always | degrade           [default: off]
+--outline-level <LEVEL>       outline | api | symbols           [default: outline]
+--outline-languages <L>...    Restrict to a subset (e.g. rust,ts,python)
+--outline-fallback <F>        full | omit  (unsupported langs)  [default: full]
+```
+
+- **`off`** — today's behavior, no parsing. (Default; protects the
+  language-agnostic identity.)
+- **`always`** — every supported file rendered at `--outline-level`; unsupported
+  files follow `--outline-fallback`. Great for "give me a map of this repo."
+- **`degrade`** — the budget-aware mode (§9): full content for as many
+  high-priority files as fit, outlines/symbols for the rest. The flagship.
+
+`yek.yaml` equivalents (config-only keys, consistent with existing style):
+
+```yaml
+outline_mode: degrade           # off | always | degrade
+outline_level: outline          # outline | api | symbols
+outline_languages: [rust, typescript, python, go, java]
+outline_fallback: full          # full | omit
+# Phase 4 — user-overridable extraction rules:
+# outline_rules:
+#   rust:
+#     - kind: function
+#       public_when: "pub"
+```
+
+## 9. Budget-aware degradation allocator (the core win)
+
+Replace the greedy single-pass cut in `concat_files` with an allocator that
+degrades least-important files instead of dropping them. Sketch:
+
+```text
+INPUT: files sorted by priority DESC (most important first), token budget `cap`
+levels = [Full, Outline, Api, Symbols]    # Omit is the implicit floor
+
+# 1. Seed every file at its cheapest non-omitted level and verify the floor fits.
+assign each file = Symbols
+if sum(cost) > cap:
+    drop lowest-priority files (Symbols → Omit) until sum(cost) <= cap
+
+# 2. Greedily upgrade, most-important-first, as long as budget allows.
+for file in files (priority DESC):
+    for level in [Api, Outline, Full]:          # progressively richer
+        delta = cost(file, level) - cost(file, current_level(file))
+        if used + delta <= cap:
+            upgrade file to level; used += delta
+        else:
+            break
+```
+
+Properties:
+
+- **Important files get full fidelity**; the tail degrades to outline/symbols
+  rather than vanishing. This is the "be smart about what is important" answer.
+- Reuses the existing **priority signal** (path rules + git recency) unchanged —
+  outline is a new *axis* (how much of each file), orthogonal to *which* files.
+- Costs are measured with the existing `count_tokens` (tiktoken) in token mode,
+  or byte length in byte mode, so it composes with `--tokens` and `--max-size`.
+- Degenerate case `outline_mode = off` ⇒ only `Full`/`Omit` exist ⇒ behaves like
+  today (and fixes the most-important-first ordering noted in §3).
+
+A simpler v1 that still delivers most of the value: **"full for high priority,
+outline for the rest"** — include full content top-down until the budget is, say,
+60% spent, then switch every remaining file to outline, then to symbols, then
+stop. Ship that first; generalize to the upgrade loop in Phase 3.
+
+## 10. Output format
+
+So the model (and humans) can tell a file was abbreviated, annotate the template
+context. Add an optional `LEVEL` placeholder and a default suffix marker:
+
+```text
+>>>> src/parallel.rs (outline)
+…signatures…
+```
+
+- Default template stays `>>>> FILE_PATH\nFILE_CONTENT`; when a file is rendered
+  below L0, `FILE_PATH` is suffixed with ` (outline)` / ` (api)` / ` (symbols)`,
+  or a new `LEVEL` token is exposed for custom templates.
+- `--json` output gains a `"level": "outline"` field per object so programmatic
+  consumers (and an MCP server) can distinguish abbreviated entries.
+
+## 11. Performance
+
+`yek`'s headline is speed; outline must not regress the default path.
+
+- Parsing happens **only** when outline mode is active and **only** for supported
+  languages, inside the existing parallel workers. Default build = no parser code
+  at all (feature-gated), zero overhead.
+- Add criterion benchmarks in `benches/serialization.rs` for an outline run over
+  a mixed-language fixture tree, tracking both wall-clock and output token count
+  (to demonstrate the budget win, not just speed).
+- Cache compiled tree-sitter languages/queries in a `OnceLock` (mirrors the
+  existing `TOKENIZER` pattern in `lib.rs`).
+- Token counting for multiple levels per file can be deferred: compute a level's
+  cost only when the allocator actually considers that level.
+
+## 12. Testing
+
+- **Per-language fixtures**: small source files → asserted outlines, one per
+  supported language (mirrors the `tests/*_test.rs` layout).
+- **Fallback**: unsupported extension (e.g. `.toml`, `.md`) stays L0 under
+  `always`; `--outline-fallback omit` drops it.
+- **Allocator**: synthetic files with known token costs assert that (a) the
+  budget is never exceeded, (b) higher-priority files end at richer levels than
+  lower-priority ones, (c) `off` mode reproduces current output exactly.
+- **Determinism**: stable ordering and stable elision markers (snapshot tests).
+- **Property test**: outline cost ≤ full cost for every fixture.
+
+## 13. Phased rollout
+
+| Phase | Deliverable |
+| --- | --- |
+| **1. Scaffold** | `src/outline/` module, `Language` + `detect_language`, tree-sitter behind Cargo feature `outline`, **Rust** extractor, `--outline` / `--outline-mode always`, `(outline)` marker, fixtures. |
+| **2. Languages** | TS/JS(+TSX), Python, Go, Java extractors; `--outline-languages`, `--outline-fallback`. |
+| **3. Degradation** | The budget-aware allocator + L2 `api` / L3 `symbols`; `--outline-mode degrade`; allocator tests + benchmark proving the token win. |
+| **4. Custom rules** | User-overridable extraction rules in `yek.yaml` (Option B layer); document how to add a language without a code change. |
+| **5. Lazy retrieval / MCP** | Outline-first serialization + an on-demand "expand symbol/file" path, exposed as MCP tools (issues #245, #232): return the repo outline, let the agent pull full bodies for chosen symbols. |
+
+Phases 1–3 deliver the full standalone value. Phases 4–5 connect it to the
+broader roadmap.
+
+## 14. Risks & open questions
+
+- **Binary size / build time.** Grammar crates are large. Mitigation: Cargo
+  feature gate (default off), curated language set, document a slim vs. full
+  build. Open question: should release artifacts ship `outline` on by default?
+- **Grammar/version drift.** Tree-sitter grammars update independently. Pin
+  versions; treat outline output as best-effort (always falls back to L0).
+- **Elision correctness.** Replacing bodies can produce technically-invalid
+  source. We optimize for LLM legibility, not compilability; markers make the
+  elision explicit. Acceptable.
+- **Token accounting cost.** Counting several levels per file adds tiktoken work.
+  Mitigation: lazy per-level costing inside the allocator.
+- **Scope of "public".** Visibility rules differ per language (Rust `pub`, JS
+  `export`, Python `_name` convention, Go capitalization). Encode per-extractor;
+  document the heuristic per language.
+
+## 15. Appendix — illustrative before/after
+
+A 1,200-line, 5-file TypeScript service, budget `--tokens 8k`:
+
+- **Today:** ~3 files fit verbatim, 2 dropped. The model never learns the
+  dropped files exist.
+- **`--outline-mode degrade`:** the 2 highest-priority files stay full; the other
+  3 collapse to outlines (exports + signatures). All 5 files are represented, the
+  budget is respected, and the model has a complete structural map plus full
+  detail where it matters most.

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,49 @@ pub enum ConfigFormat {
     Json,
 }
 
+/// How outline mode replaces file content with structural skeletons.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OutlineMode {
+    /// Disabled: emit full file content (today's behavior).
+    #[default]
+    Off,
+    /// Outline every supported file at `outline_level`.
+    Always,
+    /// Budget-aware: keep important files full, degrade the rest to outlines.
+    Degrade,
+}
+
+/// The base level of detail used when a file is outlined.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OutlineLevel {
+    /// Signatures + declarations; bodies elided.
+    #[default]
+    Outline,
+    /// Public/exported symbols only.
+    Api,
+    /// One line per symbol.
+    Symbols,
+}
+
+/// What to do with files whose language has no outline support.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OutlineFallback {
+    /// Emit the full content (default).
+    #[default]
+    Full,
+    /// Drop the file.
+    Omit,
+}
+
 #[derive(ClapConfigFile, Clone)]
 #[config_file_name = "yek"]
 #[config_file_formats = "toml,yaml,json"]
@@ -53,6 +96,27 @@ pub struct YekConfig {
     /// Output template. Defaults to ">>>> FILE_PATH\nFILE_CONTENT"
     #[config_arg(default_value = ">>>> FILE_PATH\nFILE_CONTENT")]
     pub output_template: String,
+
+    /// Shorthand for `--outline-mode always`.
+    #[config_arg()]
+    pub outline: bool,
+
+    /// Outline mode (default: off). Use `outline_mode()` for the resolved value.
+    /// Left as `Option` (no clap default) so a `yek.yaml` value is honored.
+    #[config_arg()]
+    pub outline_mode: Option<OutlineMode>,
+
+    /// Base level of detail when outlining (default: outline). See `outline_level()`.
+    #[config_arg()]
+    pub outline_level: Option<OutlineLevel>,
+
+    /// Restrict outlining to these languages (e.g. rust). Empty means all supported.
+    #[config_arg(long = "outline-languages", multi_value_behavior = "extend")]
+    pub outline_languages: Vec<String>,
+
+    /// Unsupported-language fallback when outlining (default: full). See `outline_fallback()`.
+    #[config_arg()]
+    pub outline_fallback: Option<OutlineFallback>,
 
     /// Ignore patterns
     #[config_arg(long = "ignore-patterns", multi_value_behavior = "extend")]
@@ -100,6 +164,11 @@ impl Default for YekConfig {
             debug: false,
             output_dir: None,
             output_template: DEFAULT_OUTPUT_TEMPLATE.to_string(),
+            outline: false,
+            outline_mode: None,
+            outline_level: None,
+            outline_languages: Vec::new(),
+            outline_fallback: None,
             ignore_patterns: Vec::new(),
             unignore_patterns: Vec::new(),
             priority_rules: Vec::new(),
@@ -169,6 +238,22 @@ impl YekConfig {
 
         // 2) compute derived fields:
         cfg.token_mode = !cfg.tokens.is_empty();
+
+        // `--outline` is shorthand for `--outline-mode always` (unless an explicit
+        // mode was given on the CLI or in the config file).
+        if cfg.outline && cfg.outline_mode.is_none() {
+            cfg.outline_mode = Some(OutlineMode::Always);
+        }
+
+        // Outline support is a build-time feature. If it isn't compiled in, warn
+        // once and behave as `off` so scripts that pass the flag still work.
+        if cfg.outline_active() && !cfg!(feature = "outline") {
+            eprintln!(
+                "Warning: this build of yek was compiled without the `outline` feature; \
+                 ignoring --outline/--outline-mode."
+            );
+            cfg.outline_mode = Some(OutlineMode::Off);
+        }
         let force_tty = std::env::var("FORCE_TTY").is_ok();
 
         cfg.stream = !std::io::stdout().is_terminal() && !force_tty;
@@ -283,6 +368,26 @@ impl YekConfig {
         hex[..8].to_owned()
     }
 
+    /// Resolved outline mode (`off` when unset).
+    pub fn outline_mode(&self) -> OutlineMode {
+        self.outline_mode.unwrap_or_default()
+    }
+
+    /// Resolved outline level (`outline` when unset).
+    pub fn outline_level(&self) -> OutlineLevel {
+        self.outline_level.unwrap_or_default()
+    }
+
+    /// Resolved unsupported-language fallback (`full` when unset).
+    pub fn outline_fallback(&self) -> OutlineFallback {
+        self.outline_fallback.unwrap_or_default()
+    }
+
+    /// Whether outline mode is requested (any mode other than `off`).
+    pub fn outline_active(&self) -> bool {
+        self.outline_mode() != OutlineMode::Off
+    }
+
     /// Validate the final config.
     pub fn validate(&self) -> Result<()> {
         if !self.output_template.contains("FILE_PATH")
@@ -328,6 +433,14 @@ impl YekConfig {
         for pattern in &self.ignore_patterns {
             glob::Pattern::new(pattern)
                 .map_err(|e| anyhow!("ignore_patterns: Invalid pattern '{}': {}", pattern, e))?;
+        }
+
+        // Validate outline language names (only meaningful with the feature on).
+        #[cfg(feature = "outline")]
+        for lang in &self.outline_languages {
+            if crate::outline::Language::from_name(lang).is_none() {
+                return Err(anyhow!("outline_languages: unsupported language '{}'", lang));
+            }
         }
 
         // Validate priority rules

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,15 @@ pub enum ConfigFormat {
 
 /// How outline mode replaces file content with structural skeletons.
 #[derive(
-    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum OutlineMode {
@@ -35,7 +43,15 @@ pub enum OutlineMode {
 
 /// The base level of detail used when a file is outlined.
 #[derive(
-    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum OutlineLevel {
@@ -50,7 +66,15 @@ pub enum OutlineLevel {
 
 /// What to do with files whose language has no outline support.
 #[derive(
-    Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum OutlineFallback {
@@ -439,7 +463,10 @@ impl YekConfig {
         #[cfg(feature = "outline")]
         for lang in &self.outline_languages {
             if crate::outline::Language::from_name(lang).is_none() {
-                return Err(anyhow!("outline_languages: unsupported language '{}'", lang));
+                return Err(anyhow!(
+                    "outline_languages: unsupported language '{}'",
+                    lang
+                ));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,13 @@ pub fn serialize_repo(config: &YekConfig) -> Result<(String, Vec<ProcessedFile>)
 
     let mut files = merged_files;
 
+    // Replace file contents with structural outlines when requested. Runs before
+    // the budget step so the (smaller) outlined content is what gets capped.
+    #[cfg(feature = "outline")]
+    if config.outline_active() {
+        outline::pipeline::apply(&mut files, config);
+    }
+
     // Sort final (priority asc, then file_index asc)
     files.par_sort_by(|a, b| {
         a.priority
@@ -120,24 +127,22 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
             .as_u64() as usize
     };
 
-    // Sort by priority (asc) and file_index (asc)
-    let mut sorted_files: Vec<_> = files.iter().collect();
-    sorted_files.sort_by(|a, b| {
-        a.priority
-            .cmp(&b.priority)
+    // Select most-important-first so that, when the budget is tight, it is the
+    // least important files that get dropped (not the most important ones).
+    let mut by_priority: Vec<_> = files.iter().collect();
+    by_priority.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
             .then_with(|| a.rel_path.cmp(&b.rel_path))
     });
 
     let mut files_to_include = Vec::new();
-    for file in sorted_files {
+    for file in by_priority {
         let content_size = if config.token_mode {
             // Format the file content with template first, then count tokens
             let formatted = if config.json {
-                serde_json::to_string(&serde_json::json!({
-                    "filename": &file.rel_path,
-                    "content": &file.content,
-                }))
-                .map_err(|e| anyhow!("Failed to serialize JSON: {}", e))?
+                serde_json::to_string(&file_json(file))
+                    .map_err(|e| anyhow!("Failed to serialize JSON: {}", e))?
             } else {
                 config
                     .output_template
@@ -153,22 +158,25 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
             accumulated += content_size;
             files_to_include.push(file);
         } else {
-            break;
+            // Skip this file but keep trying smaller, lower-priority ones rather
+            // than aborting — otherwise one oversized high-priority file would
+            // drop everything below it.
+            continue;
         }
     }
+
+    // Emit least-important-first so the most important files appear last, where
+    // LLMs attend most.
+    files_to_include.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then_with(|| a.rel_path.cmp(&b.rel_path))
+    });
 
     if config.json {
         // JSON array of objects
         Ok(serde_json::to_string_pretty(
-            &files_to_include
-                .iter()
-                .map(|f| {
-                    serde_json::json!({
-                        "filename": &f.rel_path,
-                        "content": &f.content,
-                    })
-                })
-                .collect::<Vec<_>>(),
+            &files_to_include.iter().map(|f| file_json(f)).collect::<Vec<_>>(),
         )?)
     } else {
         // Use the user-defined template
@@ -186,6 +194,19 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
             .collect::<Vec<_>>()
             .join("\n"))
     }
+}
+
+/// Build the JSON object for one file, including an outline `level` field when
+/// the file's content was abbreviated.
+fn file_json(file: &ProcessedFile) -> serde_json::Value {
+    let mut obj = serde_json::json!({
+        "filename": &file.rel_path,
+        "content": &file.content,
+    });
+    if let Some(level) = file.outline_level {
+        obj["level"] = serde_json::Value::String(level.to_string());
+    }
+    obj
 }
 
 /// Parse a token limit string like "800k" or "1000" into a number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use tiktoken_rs::CoreBPE;
 
 pub mod config;
 pub mod defaults;
+#[cfg(feature = "outline")]
+pub mod outline;
 pub mod parallel;
 pub mod priority;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,10 @@ pub fn concat_files(files: &[ProcessedFile], config: &YekConfig) -> anyhow::Resu
     if config.json {
         // JSON array of objects
         Ok(serde_json::to_string_pretty(
-            &files_to_include.iter().map(|f| file_json(f)).collect::<Vec<_>>(),
+            &files_to_include
+                .iter()
+                .map(|f| file_json(f))
+                .collect::<Vec<_>>(),
         )?)
     } else {
         // Use the user-defined template

--- a/src/outline/extract.rs
+++ b/src/outline/extract.rs
@@ -1,0 +1,202 @@
+//! Parse a file once and extract its declarations as a flat, tree-linked
+//! [`Symbol`] vector. Parsers are reused per thread.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use tree_sitter::{Node, Parser};
+
+use super::lang::{Language, VisibilityRule};
+use super::{Handling, Symbol};
+
+/// Hard cap on declarations recorded per file, so a pathological generated file
+/// cannot blow up memory or output.
+const MAX_SYMBOLS: usize = 2000;
+
+/// If more than this fraction of a file sits under error/missing nodes, the
+/// parse is too unreliable to outline and we fall back to full content.
+const MAX_ERROR_RATIO: f64 = 0.33;
+
+thread_local! {
+    /// One parser per (thread, language). `Parser` is `Send` but not `Sync`,
+    /// so a thread-local pool is the cheap way to reuse it across `par_iter`.
+    static PARSERS: RefCell<HashMap<Language, Parser>> = RefCell::new(HashMap::new());
+}
+
+pub(super) fn extract(source: &str, lang: Language) -> Option<Vec<Symbol>> {
+    let tree = PARSERS.with(|cell| {
+        let mut map = cell.borrow_mut();
+        let parser = map.entry(lang).or_insert_with(|| {
+            let mut p = Parser::new();
+            p.set_language(&lang.ts_language())
+                .expect("built-in grammar must load");
+            p
+        });
+        parser.parse(source.as_bytes(), None)
+    })?;
+
+    let root = tree.root_node();
+    if root.has_error() && error_ratio(root) > MAX_ERROR_RATIO {
+        return None;
+    }
+
+    let mut out: Vec<Symbol> = Vec::new();
+    // The outermost call's sink (top-level indices) is not needed: top-level
+    // symbols are identified by `depth == 0` at render time.
+    walk(root, source, lang, 0, None, &mut out, &mut Vec::new());
+
+    // No declarations ⇒ keeping full content is strictly better.
+    if out.is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+/// Recursively record declarations. `sink` receives the indices of the symbols
+/// recorded at this level (used to wire up `children`).
+fn walk(
+    node: Node,
+    source: &str,
+    lang: Language,
+    depth: u16,
+    parent_kind: Option<super::SymbolKind>,
+    out: &mut Vec<Symbol>,
+    sink: &mut Vec<u32>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if out.len() >= MAX_SYMBOLS {
+            break;
+        }
+        let Some((kind, handling)) = lang.classify(child.kind()) else {
+            continue;
+        };
+
+        let sym = build_symbol(&child, source, lang, kind, handling, depth, parent_kind);
+        let recurse_into = if sym.handling == Handling::Recurse {
+            child.child_by_field_name("body")
+        } else {
+            None
+        };
+
+        let idx = out.len() as u32;
+        out.push(sym);
+        sink.push(idx);
+
+        if let Some(body) = recurse_into {
+            // A trait `impl` makes its members public API, like trait members.
+            let child_parent = match kind {
+                super::SymbolKind::Impl if child.child_by_field_name("trait").is_some() => {
+                    super::SymbolKind::Trait
+                }
+                other => other,
+            };
+            let mut children = Vec::new();
+            walk(body, source, lang, depth + 1, Some(child_parent), out, &mut children);
+            out[idx as usize].children = children;
+        }
+    }
+}
+
+fn build_symbol(
+    node: &Node,
+    source: &str,
+    lang: Language,
+    kind: super::SymbolKind,
+    handling: Handling,
+    depth: u16,
+    parent_kind: Option<super::SymbolKind>,
+) -> Symbol {
+    let name = node.child_by_field_name("name").map(|n| n.byte_range());
+
+    let has_marker = match lang.visibility() {
+        VisibilityRule::Marker(marker) => has_child_kind(node, marker),
+    };
+    // Members of a trait are part of its public interface even without a marker.
+    let is_public = has_marker || parent_kind == Some(super::SymbolKind::Trait);
+
+    let body = node.child_by_field_name("body");
+    let (handling, body_open, body_lines) = match (handling, body) {
+        (Handling::Elide, Some(b)) => (
+            Handling::Elide,
+            Some(b.start_byte()),
+            // Lines of hidden content: the `{` and `}` lines stay, so exclude them.
+            (b.end_position().row.saturating_sub(b.start_position().row).saturating_sub(1)) as u32,
+        ),
+        (Handling::Recurse, Some(b)) => (Handling::Recurse, Some(b.start_byte()), 0),
+        // No body to elide or recurse into (e.g. `mod foo;`, `fn f();`, a struct)
+        // ⇒ show the declaration verbatim.
+        _ => (Handling::ShowFull, None, 0),
+    };
+
+    Symbol {
+        kind,
+        is_public,
+        handling,
+        name,
+        node: node.byte_range(),
+        lead_start: lead_start(node, source),
+        body_open,
+        body_lines,
+        start_row: node.start_position().row,
+        end_row: node.end_position().row,
+        depth,
+        children: Vec::new(),
+    }
+}
+
+/// Extend a declaration's start backward over any contiguous leading attributes
+/// (`#[...]`) and doc comments (`///`, `//!`, `/** */`, `/*! */`), which the
+/// grammar represents as preceding siblings rather than children.
+fn lead_start(node: &Node, source: &str) -> usize {
+    let mut start = node.start_byte();
+    let mut top_row = node.start_position().row;
+    let mut sibling = node.prev_sibling();
+    while let Some(s) = sibling {
+        let is_doc = matches!(s.kind(), "line_comment" | "block_comment")
+            && is_doc_comment(&source[s.byte_range()]);
+        if !(s.kind() == "attribute_item" || is_doc) {
+            break;
+        }
+        // Stop if a blank line detaches the trivia from the declaration.
+        if s.end_position().row + 1 < top_row {
+            break;
+        }
+        start = s.start_byte();
+        top_row = s.start_position().row;
+        sibling = s.prev_sibling();
+    }
+    start
+}
+
+fn is_doc_comment(text: &str) -> bool {
+    text.starts_with("///") || text.starts_with("//!") || text.starts_with("/**") || text.starts_with("/*!")
+}
+
+/// Whether `node` has a direct child of the given kind. The intermediate
+/// binding is required: it drops the `Children` iterator (and its borrow of
+/// `cursor`) before `cursor` itself goes out of scope.
+fn has_child_kind(node: &Node, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    let found = node.children(&mut cursor).any(|c| c.kind() == kind);
+    found
+}
+
+/// Fraction of bytes covered by error/missing nodes (computed only when the tree
+/// is known to contain at least one error).
+fn error_ratio(root: Node) -> f64 {
+    let total = root.byte_range().len().max(1);
+    let mut errored = 0usize;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            errored += node.byte_range().len();
+            continue; // children are already counted within this range
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    errored as f64 / total as f64
+}

--- a/src/outline/extract.rs
+++ b/src/outline/extract.rs
@@ -92,7 +92,15 @@ fn walk(
                 other => other,
             };
             let mut children = Vec::new();
-            walk(body, source, lang, depth + 1, Some(child_parent), out, &mut children);
+            walk(
+                body,
+                source,
+                lang,
+                depth + 1,
+                Some(child_parent),
+                out,
+                &mut children,
+            );
             out[idx as usize].children = children;
         }
     }
@@ -121,7 +129,10 @@ fn build_symbol(
             Handling::Elide,
             Some(b.start_byte()),
             // Lines of hidden content: the `{` and `}` lines stay, so exclude them.
-            (b.end_position().row.saturating_sub(b.start_position().row).saturating_sub(1)) as u32,
+            (b.end_position()
+                .row
+                .saturating_sub(b.start_position().row)
+                .saturating_sub(1)) as u32,
         ),
         (Handling::Recurse, Some(b)) => (Handling::Recurse, Some(b.start_byte()), 0),
         // No body to elide or recurse into (e.g. `mod foo;`, `fn f();`, a struct)
@@ -170,7 +181,10 @@ fn lead_start(node: &Node, source: &str) -> usize {
 }
 
 fn is_doc_comment(text: &str) -> bool {
-    text.starts_with("///") || text.starts_with("//!") || text.starts_with("/**") || text.starts_with("/*!")
+    text.starts_with("///")
+        || text.starts_with("//!")
+        || text.starts_with("/**")
+        || text.starts_with("/*!")
 }
 
 /// Whether `node` has a direct child of the given kind. The intermediate

--- a/src/outline/lang.rs
+++ b/src/outline/lang.rs
@@ -1,0 +1,106 @@
+//! Per-language configuration for outline extraction.
+//!
+//! Languages are described as *data*: a node-kind classification table plus a
+//! visibility rule and an elision style. Adding a language is adding a grammar
+//! dependency and a few match arms — no new control flow.
+
+use std::path::Path;
+
+use super::{Handling, SymbolKind};
+
+/// A source language yek can outline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Language {
+    Rust,
+}
+
+/// How to decide whether a declaration is part of the public API.
+#[derive(Clone, Copy)]
+pub(crate) enum VisibilityRule {
+    /// Public iff the node has a direct child of this kind (e.g. Rust `pub`).
+    Marker(&'static str),
+}
+
+/// How elided bodies are rendered.
+#[derive(Clone, Copy)]
+pub(crate) enum ElisionStyle {
+    /// C-like: ` { /* … N lines … */ }`.
+    Braces,
+}
+
+impl Language {
+    /// All languages compiled into this build.
+    pub fn all() -> &'static [Language] {
+        &[Language::Rust]
+    }
+
+    /// Canonical lowercase name, used by `--outline-languages` and `--json`.
+    pub fn name(self) -> &'static str {
+        match self {
+            Language::Rust => "rust",
+        }
+    }
+
+    /// Parse a user-supplied language name (for `--outline-languages`).
+    pub fn from_name(name: &str) -> Option<Language> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "rust" | "rs" => Some(Language::Rust),
+            _ => None,
+        }
+    }
+
+    /// The tree-sitter grammar for this language.
+    pub(crate) fn ts_language(self) -> tree_sitter::Language {
+        match self {
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+        }
+    }
+
+    /// Map a grammar node kind to a symbol kind and how to render its body.
+    /// Returns `None` for nodes that are not outline-worthy declarations.
+    pub(crate) fn classify(self, node_kind: &str) -> Option<(SymbolKind, Handling)> {
+        match self {
+            Language::Rust => match node_kind {
+                "function_item" => Some((SymbolKind::Function, Handling::Elide)),
+                // Bodyless trait method / associated declarations: show verbatim.
+                "function_signature_item" => Some((SymbolKind::Function, Handling::ShowFull)),
+                "associated_type" => Some((SymbolKind::Type, Handling::ShowFull)),
+                // `macro_definition` has no `body` field, so its rules cannot be
+                // elided generically yet; show it verbatim rather than pretending.
+                "macro_definition" => Some((SymbolKind::Macro, Handling::ShowFull)),
+                "struct_item" => Some((SymbolKind::Struct, Handling::ShowFull)),
+                "enum_item" => Some((SymbolKind::Enum, Handling::ShowFull)),
+                "union_item" => Some((SymbolKind::Union, Handling::ShowFull)),
+                "type_item" => Some((SymbolKind::Type, Handling::ShowFull)),
+                "const_item" => Some((SymbolKind::Const, Handling::ShowFull)),
+                "static_item" => Some((SymbolKind::Static, Handling::ShowFull)),
+                "use_declaration" => Some((SymbolKind::Import, Handling::ShowFull)),
+                "trait_item" => Some((SymbolKind::Trait, Handling::Recurse)),
+                "impl_item" => Some((SymbolKind::Impl, Handling::Recurse)),
+                "mod_item" => Some((SymbolKind::Module, Handling::Recurse)),
+                _ => None,
+            },
+        }
+    }
+
+    pub(crate) fn visibility(self) -> VisibilityRule {
+        match self {
+            Language::Rust => VisibilityRule::Marker("visibility_modifier"),
+        }
+    }
+
+    pub(crate) fn elision(self) -> ElisionStyle {
+        match self {
+            Language::Rust => ElisionStyle::Braces,
+        }
+    }
+}
+
+/// Detect a supported language from a file path's extension.
+pub fn detect_language(rel_path: &str) -> Option<Language> {
+    let ext = Path::new(rel_path).extension()?.to_str()?;
+    match ext {
+        "rs" => Some(Language::Rust),
+        _ => None,
+    }
+}

--- a/src/outline/mod.rs
+++ b/src/outline/mod.rs
@@ -8,6 +8,7 @@
 
 mod extract;
 mod lang;
+pub mod pipeline;
 mod render;
 
 #[cfg(test)]

--- a/src/outline/mod.rs
+++ b/src/outline/mod.rs
@@ -1,0 +1,119 @@
+//! Outline mode: compact structural skeletons of source files so more of a repo
+//! fits in a fixed context budget. Opt-in, behind the `outline` Cargo feature.
+//!
+//! The engine parses a file **once** with tree-sitter, extracts declarations as
+//! [`Symbol`]s that hold byte *ranges* into the original source (no copies), and
+//! renders any [`OutlineLevel`] on demand by slicing that source. This keeps
+//! memory low and lets the budget allocator pick a level per file cheaply.
+
+mod extract;
+mod lang;
+mod render;
+
+#[cfg(test)]
+mod tests;
+
+pub use lang::{detect_language, Language};
+
+use std::ops::Range;
+
+/// Levels of detail for a file, richest first. `Omit` (dropping a file) is the
+/// allocator's job, not this module's.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutlineLevel {
+    /// Verbatim file content.
+    Full,
+    /// Signatures + declarations; function/method bodies elided.
+    Outline,
+    /// Like `Outline` but public/exported symbols only.
+    Api,
+    /// One line per symbol: kind, name, and line range.
+    Symbols,
+}
+
+/// What a declaration is. Used for the `Symbols` listing and to decide rendering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SymbolKind {
+    Module,
+    Import,
+    Struct,
+    Enum,
+    Union,
+    Trait,
+    Impl,
+    Function,
+    Type,
+    Const,
+    Static,
+    Macro,
+}
+
+impl SymbolKind {
+    fn label(self) -> &'static str {
+        match self {
+            SymbolKind::Module => "mod",
+            SymbolKind::Import => "use",
+            SymbolKind::Struct => "struct",
+            SymbolKind::Enum => "enum",
+            SymbolKind::Union => "union",
+            SymbolKind::Trait => "trait",
+            SymbolKind::Impl => "impl",
+            SymbolKind::Function => "fn",
+            SymbolKind::Type => "type",
+            SymbolKind::Const => "const",
+            SymbolKind::Static => "static",
+            SymbolKind::Macro => "macro",
+        }
+    }
+}
+
+/// How a symbol's body is treated below `Full`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Handling {
+    /// Code body replaced by an elision marker (functions/methods).
+    Elide,
+    /// Container: print the header, then render child items (impl/trait/mod).
+    Recurse,
+    /// Print the whole declaration verbatim (struct/enum/type/const/use/...).
+    ShowFull,
+}
+
+/// One extracted declaration. All positions are byte ranges into the file's
+/// source string, so rendering never copies text until the final slice.
+#[derive(Clone, Debug)]
+pub struct Symbol {
+    pub kind: SymbolKind,
+    pub is_public: bool,
+    pub handling: Handling,
+    /// Identifier range, when the node exposes a `name` field (impl blocks do not).
+    pub name: Option<Range<usize>>,
+    /// Full declaration range (the item itself, excluding leading trivia).
+    pub node: Range<usize>,
+    /// Byte where rendering begins: `node.start`, extended back over any
+    /// contiguous leading attributes (`#[...]`) and doc comments (`///`).
+    pub lead_start: usize,
+    /// Byte offset of the body's opening delimiter (for `Elide`/`Recurse`).
+    pub body_open: Option<usize>,
+    /// Number of source lines hidden by an `Elide`, for the marker.
+    pub body_lines: u32,
+    pub start_row: usize,
+    pub end_row: usize,
+    /// Nesting depth (0 = top level).
+    pub depth: u16,
+    /// Indices into the owning file's symbol vector.
+    pub children: Vec<u32>,
+}
+
+/// Parse `source` and extract its declarations.
+///
+/// Returns `None` when the language is unsupported, the parse is too broken to
+/// trust, or the outline would carry no signal — in every such case the caller
+/// should fall back to the full file content.
+pub fn extract(source: &str, lang: Language) -> Option<Vec<Symbol>> {
+    extract::extract(source, lang)
+}
+
+/// Render previously-extracted `symbols` at `level` by slicing `source`.
+pub fn render(source: &str, lang: Language, symbols: &[Symbol], level: OutlineLevel) -> String {
+    render::render(source, lang, symbols, level)
+}

--- a/src/outline/pipeline.rs
+++ b/src/outline/pipeline.rs
@@ -1,0 +1,133 @@
+//! Apply outline rendering to processed files according to the configured mode.
+//!
+//! Runs after files are read and before the budget step in `concat_files`.
+
+use std::str::FromStr;
+
+use bytesize::ByteSize;
+use rayon::prelude::*;
+
+use super::{detect_language, extract, render, Language, OutlineLevel};
+use crate::config::{OutlineFallback, OutlineLevel as CfgLevel, OutlineMode, YekConfig};
+use crate::parallel::ProcessedFile;
+
+/// Transform `files` in place according to `config`'s outline mode.
+pub fn apply(files: &mut Vec<ProcessedFile>, config: &YekConfig) {
+    let level = cfg_to_level(config.outline_level());
+    let tag = tag(config.outline_level());
+    let restrict = &config.outline_languages;
+
+    match config.outline_mode() {
+        OutlineMode::Off => {}
+        OutlineMode::Always => {
+            files.par_iter_mut().for_each(|f| {
+                if let Some(rendered) = outline_one(&f.rel_path, &f.content, restrict, level) {
+                    f.content = display(config, tag, &rendered);
+                    f.outline_level = Some(tag);
+                }
+            });
+            if config.outline_fallback() == OutlineFallback::Omit {
+                files.retain(|f| f.outline_level.is_some());
+            }
+        }
+        OutlineMode::Degrade => degrade(files, config, level, tag),
+    }
+}
+
+/// Budget-aware (simple): keep the highest-priority files at full content until
+/// roughly half the budget is spent, then outline the remaining supported files.
+/// The final hard cap is still enforced by `concat_files`.
+fn degrade(files: &mut [ProcessedFile], config: &YekConfig, level: OutlineLevel, tag: &'static str) {
+    // Pre-render outlines in parallel; only supported files yield `Some`.
+    let outlines: Vec<Option<String>> = files
+        .par_iter()
+        .map(|f| outline_one(&f.rel_path, &f.content, &config.outline_languages, level))
+        .collect();
+
+    let full_budget = budget(config) / 2;
+
+    // Decide in priority-descending order so important files keep full content.
+    let mut order: Vec<usize> = (0..files.len()).collect();
+    order.sort_by(|&a, &b| {
+        files[b]
+            .priority
+            .cmp(&files[a].priority)
+            .then_with(|| files[a].rel_path.cmp(&files[b].rel_path))
+    });
+
+    let mut used = 0usize;
+    for i in order {
+        let full_cost = cost(config, &files[i].content);
+        if used + full_cost <= full_budget {
+            used += full_cost; // keep full content
+        } else if let Some(rendered) = &outlines[i] {
+            files[i].content = display(config, tag, rendered);
+            files[i].outline_level = Some(tag);
+        }
+        // Unsupported files that don't fit stay full; `concat_files` caps them.
+    }
+}
+
+/// Render `content` as an outline, or `None` if the language is unsupported (or
+/// excluded by `restrict`), the parse is unusable, or there is nothing to show.
+fn outline_one(
+    rel_path: &str,
+    content: &str,
+    restrict: &[String],
+    level: OutlineLevel,
+) -> Option<String> {
+    let lang = detect_language(rel_path)?;
+    if !restrict.is_empty() && !restrict.iter().any(|r| Language::from_name(r) == Some(lang)) {
+        return None;
+    }
+    let symbols = extract(content, lang)?;
+    Some(render(content, lang, &symbols, level))
+}
+
+/// Text output marks outlined files so a reader knows the content is abbreviated;
+/// JSON output omits the marker and relies on the structured `level` field.
+fn display(config: &YekConfig, tag: &str, rendered: &str) -> String {
+    if config.json {
+        rendered.to_string()
+    } else {
+        format!("⟪yek:{tag}⟫\n{rendered}")
+    }
+}
+
+fn budget(config: &YekConfig) -> usize {
+    if config.token_mode {
+        crate::parse_token_limit(&config.tokens).unwrap_or(usize::MAX)
+    } else {
+        ByteSize::from_str(&config.max_size)
+            .map(|b| b.as_u64() as usize)
+            .unwrap_or(usize::MAX)
+    }
+}
+
+/// Approximate per-file cost. This counts the raw content only, not the template
+/// or JSON wrapper that `concat_files` adds, so it slightly under-counts. The
+/// `cap / 2` headroom for full content plus `concat_files`' exact final cap make
+/// that approximation safe; a future budget allocator can cost levels exactly.
+fn cost(config: &YekConfig, content: &str) -> usize {
+    if config.token_mode {
+        crate::count_tokens(content)
+    } else {
+        content.len()
+    }
+}
+
+fn cfg_to_level(level: CfgLevel) -> OutlineLevel {
+    match level {
+        CfgLevel::Outline => OutlineLevel::Outline,
+        CfgLevel::Api => OutlineLevel::Api,
+        CfgLevel::Symbols => OutlineLevel::Symbols,
+    }
+}
+
+fn tag(level: CfgLevel) -> &'static str {
+    match level {
+        CfgLevel::Outline => "outline",
+        CfgLevel::Api => "api",
+        CfgLevel::Symbols => "symbols",
+    }
+}

--- a/src/outline/pipeline.rs
+++ b/src/outline/pipeline.rs
@@ -37,7 +37,12 @@ pub fn apply(files: &mut Vec<ProcessedFile>, config: &YekConfig) {
 /// Budget-aware (simple): keep the highest-priority files at full content until
 /// roughly half the budget is spent, then outline the remaining supported files.
 /// The final hard cap is still enforced by `concat_files`.
-fn degrade(files: &mut [ProcessedFile], config: &YekConfig, level: OutlineLevel, tag: &'static str) {
+fn degrade(
+    files: &mut [ProcessedFile],
+    config: &YekConfig,
+    level: OutlineLevel,
+    tag: &'static str,
+) {
     // Pre-render outlines in parallel; only supported files yield `Some`.
     let outlines: Vec<Option<String>> = files
         .par_iter()
@@ -77,7 +82,11 @@ fn outline_one(
     level: OutlineLevel,
 ) -> Option<String> {
     let lang = detect_language(rel_path)?;
-    if !restrict.is_empty() && !restrict.iter().any(|r| Language::from_name(r) == Some(lang)) {
+    if !restrict.is_empty()
+        && !restrict
+            .iter()
+            .any(|r| Language::from_name(r) == Some(lang))
+    {
         return None;
     }
     let symbols = extract(content, lang)?;

--- a/src/outline/render.rs
+++ b/src/outline/render.rs
@@ -1,0 +1,140 @@
+//! Render extracted symbols at a chosen level by slicing the original source.
+//!
+//! Each declaration is sliced from its own start token and re-indented by its
+//! nesting depth, so the output reads like the source with bodies elided and
+//! stays correct even when several declarations share a source line
+//! (e.g. `trait T { fn go(); }`).
+
+use std::fmt::Write;
+
+use super::lang::{ElisionStyle, Language};
+use super::{Handling, OutlineLevel, Symbol};
+
+/// Spaces used per nesting level when re-indenting rendered declarations.
+const INDENT: &str = "    ";
+
+pub(super) fn render(
+    source: &str,
+    lang: Language,
+    symbols: &[Symbol],
+    level: OutlineLevel,
+) -> String {
+    match level {
+        OutlineLevel::Full => source.to_string(),
+        OutlineLevel::Outline => render_tree(source, lang, symbols, false),
+        OutlineLevel::Api => render_tree(source, lang, symbols, true),
+        OutlineLevel::Symbols => render_symbols(source, symbols),
+    }
+}
+
+fn render_tree(source: &str, lang: Language, symbols: &[Symbol], api_only: bool) -> String {
+    let mut buf = String::new();
+    for (i, sym) in symbols.iter().enumerate() {
+        if sym.depth != 0 {
+            continue; // nested items are emitted by their parent
+        }
+        if api_only && !subtree_visible(symbols, i) {
+            continue;
+        }
+        render_one(source, lang, symbols, i, api_only, &mut buf);
+    }
+    buf
+}
+
+fn render_one(
+    source: &str,
+    lang: Language,
+    symbols: &[Symbol],
+    idx: usize,
+    api_only: bool,
+    buf: &mut String,
+) {
+    let sym = &symbols[idx];
+    // Re-indent by depth rather than copying the source's leading whitespace, so
+    // output stays correct when several declarations share a line.
+    let indent = INDENT.repeat(sym.depth as usize);
+
+    match sym.handling {
+        Handling::ShowFull => {
+            buf.push_str(&indent);
+            buf.push_str(&source[sym.lead_start..sym.node.end]);
+            buf.push('\n');
+        }
+        Handling::Elide => {
+            let open = sym.body_open.unwrap_or(sym.node.end);
+            buf.push_str(&indent);
+            buf.push_str(source[sym.lead_start..open].trim_end());
+            buf.push_str(&elide_marker(lang, sym.body_lines));
+            buf.push('\n');
+        }
+        Handling::Recurse => {
+            let open = sym.body_open.unwrap_or(sym.node.end);
+            buf.push_str(&indent);
+            buf.push_str(source[sym.lead_start..open].trim_end());
+            buf.push_str(" {\n");
+            for &child in &sym.children {
+                if api_only && !subtree_visible(symbols, child as usize) {
+                    continue;
+                }
+                render_one(source, lang, symbols, child as usize, api_only, buf);
+            }
+            buf.push_str(&indent);
+            buf.push_str("}\n");
+        }
+    }
+}
+
+fn render_symbols(source: &str, symbols: &[Symbol]) -> String {
+    let mut buf = String::new();
+    for sym in symbols {
+        let pad = "  ".repeat(sym.depth as usize);
+        let _ = writeln!(
+            buf,
+            "{}{} (L{}-{})",
+            pad,
+            symbol_label(source, sym),
+            sym.start_row + 1,
+            sym.end_row + 1,
+        );
+    }
+    buf
+}
+
+/// Display label for the `Symbols` listing. Named declarations read as
+/// `kind name` (e.g. `fn area`); nameless ones (`impl`, `use`) fall back to the
+/// first line of the declaration, which already carries the keyword.
+fn symbol_label(source: &str, sym: &Symbol) -> String {
+    if let Some(name) = &sym.name {
+        return format!("{} {}", sym.kind.label(), &source[name.clone()]);
+    }
+    let end = sym.body_open.unwrap_or(sym.node.end);
+    let head = &source[sym.node.start..end];
+    head.split(['\n', '{', '(']).next().unwrap_or(head).trim().to_string()
+}
+
+fn elide_marker(lang: Language, lines: u32) -> String {
+    match lang.elision() {
+        ElisionStyle::Braces => {
+            if lines > 1 {
+                format!(" {{ /* … {lines} lines … */ }}")
+            } else {
+                " { /* … */ }".to_string()
+            }
+        }
+    }
+}
+
+/// Is `idx` shown at `Api` level? A leaf is shown when public; a container is
+/// shown when public or when it holds any visible descendant.
+fn subtree_visible(symbols: &[Symbol], idx: usize) -> bool {
+    let sym = &symbols[idx];
+    if sym.handling != Handling::Recurse {
+        return sym.is_public;
+    }
+    if sym.is_public {
+        return true;
+    }
+    sym.children
+        .iter()
+        .any(|&c| subtree_visible(symbols, c as usize))
+}

--- a/src/outline/render.rs
+++ b/src/outline/render.rs
@@ -109,7 +109,11 @@ fn symbol_label(source: &str, sym: &Symbol) -> String {
     }
     let end = sym.body_open.unwrap_or(sym.node.end);
     let head = &source[sym.node.start..end];
-    head.split(['\n', '{', '(']).next().unwrap_or(head).trim().to_string()
+    head.split(['\n', '{', '('])
+        .next()
+        .unwrap_or(head)
+        .trim()
+        .to_string()
 }
 
 fn elide_marker(lang: Language, lines: u32) -> String {

--- a/src/outline/tests.rs
+++ b/src/outline/tests.rs
@@ -1,0 +1,181 @@
+use super::{detect_language, extract, render, Language, OutlineLevel};
+
+const SAMPLE: &str = r#"use std::collections::HashMap;
+
+/// A point in 2D space.
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+enum Shape {
+    Circle(f64),
+    Square(f64),
+}
+
+pub fn area(s: &Shape) -> f64 {
+    match s {
+        Shape::Circle(r) => 3.14159 * r * r,
+        Shape::Square(a) => a * a,
+    }
+}
+
+fn helper() -> i32 {
+    let mut total = 0;
+    for i in 0..10 {
+        total += i;
+    }
+    total
+}
+
+pub trait Drawable {
+    fn draw(&self);
+}
+
+impl Point {
+    pub fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+    fn private_helper(&self) -> i32 {
+        self.x + self.y
+    }
+}
+
+impl Drawable for Point {
+    fn draw(&self) {
+        println!("draw");
+    }
+}
+"#;
+
+fn outline(level: OutlineLevel) -> String {
+    let symbols = extract(SAMPLE, Language::Rust).expect("sample has symbols");
+    render(SAMPLE, Language::Rust, &symbols, level)
+}
+
+#[test]
+fn detects_language_by_extension() {
+    assert_eq!(detect_language("src/main.rs"), Some(Language::Rust));
+    assert_eq!(detect_language("a/b/lib.rs"), Some(Language::Rust));
+    assert_eq!(detect_language("README.md"), None);
+    assert_eq!(detect_language("Makefile"), None);
+    assert_eq!(detect_language("script.py"), None);
+}
+
+#[test]
+fn full_level_is_verbatim() {
+    let symbols = extract(SAMPLE, Language::Rust).unwrap();
+    assert_eq!(render(SAMPLE, Language::Rust, &symbols, OutlineLevel::Full), SAMPLE);
+}
+
+#[test]
+fn outline_keeps_signatures_and_elides_bodies() {
+    let out = outline(OutlineLevel::Outline);
+
+    // Signatures are present.
+    assert!(out.contains("pub fn area(s: &Shape) -> f64"), "got:\n{out}");
+    assert!(out.contains("fn helper() -> i32"), "private fn shown at Outline");
+
+    // Bodies are gone.
+    assert!(!out.contains("3.14159"), "area body should be elided:\n{out}");
+    assert!(!out.contains("total += i"), "helper body should be elided:\n{out}");
+    assert!(out.contains("/* …"), "elision marker missing:\n{out}");
+
+    // Declarations (struct fields, enum variants) are shown verbatim.
+    assert!(out.contains("pub struct Point"));
+    assert!(out.contains("pub x: i32"));
+    assert!(out.contains("Circle(f64)"));
+
+    // Containers recurse: header, nested signature, closing brace.
+    assert!(out.contains("impl Drawable for Point {"), "got:\n{out}");
+    assert!(out.contains("fn draw(&self)"));
+
+    // A bodyless trait method is kept verbatim (function_signature_item).
+    assert!(out.contains("fn draw(&self);"), "trait method dropped:\n{out}");
+}
+
+#[test]
+fn api_level_drops_private_symbols() {
+    let out = outline(OutlineLevel::Api);
+
+    assert!(out.contains("pub fn area"), "got:\n{out}");
+    assert!(out.contains("pub fn origin"), "public method kept:\n{out}");
+    assert!(out.contains("fn draw"), "trait impl method is public API:\n{out}");
+
+    assert!(!out.contains("fn helper"), "private free fn dropped:\n{out}");
+    assert!(!out.contains("private_helper"), "private method dropped:\n{out}");
+}
+
+#[test]
+fn symbols_level_lists_declarations() {
+    let out = outline(OutlineLevel::Symbols);
+    assert!(out.contains("struct Point"));
+    assert!(out.contains("fn area"));
+    assert!(out.contains("trait Drawable"));
+    // Line ranges are emitted.
+    assert!(out.contains("(L"));
+    // Nested methods are indented under their container.
+    assert!(out.contains("  fn draw"), "got:\n{out}");
+    // Nameless declarations are not double-prefixed with their keyword.
+    assert!(!out.contains("use use"), "doubled keyword:\n{out}");
+    assert!(!out.contains("impl impl"), "doubled keyword:\n{out}");
+    assert!(out.contains("impl Point"));
+}
+
+#[test]
+fn returns_none_when_nothing_to_outline() {
+    // No top-level declarations to summarize.
+    assert!(extract("let x = 1 + 2;\n", Language::Rust).is_none());
+    assert!(extract("", Language::Rust).is_none());
+}
+
+#[test]
+fn language_name_round_trips() {
+    for &lang in Language::all() {
+        assert_eq!(Language::from_name(lang.name()), Some(lang));
+    }
+}
+
+#[test]
+fn single_line_container_does_not_duplicate_header_or_leak_bodies() {
+    // Regression: rendering a container whose members share its line must not
+    // re-emit the header or leak un-elided bodies.
+    let src = "impl S { pub fn a(&self) -> i32 { 1 } pub fn b(&self) -> i32 { 2 } }\n";
+    let symbols = extract(src, Language::Rust).unwrap();
+    let out = render(src, Language::Rust, &symbols, OutlineLevel::Outline);
+
+    assert_eq!(out.matches("impl S").count(), 1, "header duplicated:\n{out}");
+    assert!(!out.contains("{ 1 }"), "body leaked un-elided:\n{out}");
+    assert!(!out.contains("{ 2 }"), "body leaked un-elided:\n{out}");
+    assert!(out.contains("pub fn a(&self) -> i32"));
+    assert!(out.contains("pub fn b(&self) -> i32"));
+}
+
+#[test]
+fn outline_keeps_attributes_and_doc_comments() {
+    let src = "/// The config.\n#[derive(Debug, Clone)]\npub struct Config {\n    pub name: String,\n}\n";
+    let symbols = extract(src, Language::Rust).unwrap();
+    let out = render(src, Language::Rust, &symbols, OutlineLevel::Outline);
+
+    assert!(out.contains("/// The config."), "doc dropped:\n{out}");
+    assert!(out.contains("#[derive(Debug, Clone)]"), "attribute dropped:\n{out}");
+    assert!(out.contains("pub struct Config"));
+}
+
+#[test]
+fn elide_marker_counts_hidden_content_lines() {
+    // Body spans rows 0..4 ({ on row 0, } on row 4) with 3 content lines.
+    let src = "pub fn f() {\n    a();\n    b();\n    c();\n}\n";
+    let symbols = extract(src, Language::Rust).unwrap();
+    let out = render(src, Language::Rust, &symbols, OutlineLevel::Outline);
+    assert!(out.contains("3 lines"), "wrong hidden line count:\n{out}");
+}
+
+#[test]
+fn handles_multibyte_source_without_panicking() {
+    let src = "/// café ☕ 漢字\npub fn naïve() -> &'static str {\n    \"日本語 😀\"\n}\n";
+    let symbols = extract(src, Language::Rust).unwrap();
+    for level in [OutlineLevel::Outline, OutlineLevel::Api, OutlineLevel::Symbols] {
+        let _ = render(src, Language::Rust, &symbols, level);
+    }
+}

--- a/src/outline/tests.rs
+++ b/src/outline/tests.rs
@@ -65,7 +65,10 @@ fn detects_language_by_extension() {
 #[test]
 fn full_level_is_verbatim() {
     let symbols = extract(SAMPLE, Language::Rust).unwrap();
-    assert_eq!(render(SAMPLE, Language::Rust, &symbols, OutlineLevel::Full), SAMPLE);
+    assert_eq!(
+        render(SAMPLE, Language::Rust, &symbols, OutlineLevel::Full),
+        SAMPLE
+    );
 }
 
 #[test]
@@ -74,11 +77,20 @@ fn outline_keeps_signatures_and_elides_bodies() {
 
     // Signatures are present.
     assert!(out.contains("pub fn area(s: &Shape) -> f64"), "got:\n{out}");
-    assert!(out.contains("fn helper() -> i32"), "private fn shown at Outline");
+    assert!(
+        out.contains("fn helper() -> i32"),
+        "private fn shown at Outline"
+    );
 
     // Bodies are gone.
-    assert!(!out.contains("3.14159"), "area body should be elided:\n{out}");
-    assert!(!out.contains("total += i"), "helper body should be elided:\n{out}");
+    assert!(
+        !out.contains("3.14159"),
+        "area body should be elided:\n{out}"
+    );
+    assert!(
+        !out.contains("total += i"),
+        "helper body should be elided:\n{out}"
+    );
     assert!(out.contains("/* …"), "elision marker missing:\n{out}");
 
     // Declarations (struct fields, enum variants) are shown verbatim.
@@ -91,7 +103,10 @@ fn outline_keeps_signatures_and_elides_bodies() {
     assert!(out.contains("fn draw(&self)"));
 
     // A bodyless trait method is kept verbatim (function_signature_item).
-    assert!(out.contains("fn draw(&self);"), "trait method dropped:\n{out}");
+    assert!(
+        out.contains("fn draw(&self);"),
+        "trait method dropped:\n{out}"
+    );
 }
 
 #[test]
@@ -100,10 +115,19 @@ fn api_level_drops_private_symbols() {
 
     assert!(out.contains("pub fn area"), "got:\n{out}");
     assert!(out.contains("pub fn origin"), "public method kept:\n{out}");
-    assert!(out.contains("fn draw"), "trait impl method is public API:\n{out}");
+    assert!(
+        out.contains("fn draw"),
+        "trait impl method is public API:\n{out}"
+    );
 
-    assert!(!out.contains("fn helper"), "private free fn dropped:\n{out}");
-    assert!(!out.contains("private_helper"), "private method dropped:\n{out}");
+    assert!(
+        !out.contains("fn helper"),
+        "private free fn dropped:\n{out}"
+    );
+    assert!(
+        !out.contains("private_helper"),
+        "private method dropped:\n{out}"
+    );
 }
 
 #[test]
@@ -144,7 +168,11 @@ fn single_line_container_does_not_duplicate_header_or_leak_bodies() {
     let symbols = extract(src, Language::Rust).unwrap();
     let out = render(src, Language::Rust, &symbols, OutlineLevel::Outline);
 
-    assert_eq!(out.matches("impl S").count(), 1, "header duplicated:\n{out}");
+    assert_eq!(
+        out.matches("impl S").count(),
+        1,
+        "header duplicated:\n{out}"
+    );
     assert!(!out.contains("{ 1 }"), "body leaked un-elided:\n{out}");
     assert!(!out.contains("{ 2 }"), "body leaked un-elided:\n{out}");
     assert!(out.contains("pub fn a(&self) -> i32"));
@@ -153,12 +181,16 @@ fn single_line_container_does_not_duplicate_header_or_leak_bodies() {
 
 #[test]
 fn outline_keeps_attributes_and_doc_comments() {
-    let src = "/// The config.\n#[derive(Debug, Clone)]\npub struct Config {\n    pub name: String,\n}\n";
+    let src =
+        "/// The config.\n#[derive(Debug, Clone)]\npub struct Config {\n    pub name: String,\n}\n";
     let symbols = extract(src, Language::Rust).unwrap();
     let out = render(src, Language::Rust, &symbols, OutlineLevel::Outline);
 
     assert!(out.contains("/// The config."), "doc dropped:\n{out}");
-    assert!(out.contains("#[derive(Debug, Clone)]"), "attribute dropped:\n{out}");
+    assert!(
+        out.contains("#[derive(Debug, Clone)]"),
+        "attribute dropped:\n{out}"
+    );
     assert!(out.contains("pub struct Config"));
 }
 
@@ -175,7 +207,11 @@ fn elide_marker_counts_hidden_content_lines() {
 fn handles_multibyte_source_without_panicking() {
     let src = "/// café ☕ 漢字\npub fn naïve() -> &'static str {\n    \"日本語 😀\"\n}\n";
     let symbols = extract(src, Language::Rust).unwrap();
-    for level in [OutlineLevel::Outline, OutlineLevel::Api, OutlineLevel::Symbols] {
+    for level in [
+        OutlineLevel::Outline,
+        OutlineLevel::Api,
+        OutlineLevel::Symbols,
+    ] {
         let _ = render(src, Language::Rust, &symbols, level);
     }
 }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -18,6 +18,9 @@ pub struct ProcessedFile {
     pub file_index: usize,
     pub rel_path: String,
     pub content: String,
+    /// Tag of the outline level applied to `content` (e.g. "outline"), or `None`
+    /// when `content` is the verbatim file. Drives the `--json` `level` field.
+    pub outline_level: Option<&'static str>,
 }
 
 /// Process a single file, checking ignore patterns and reading its contents.
@@ -63,6 +66,7 @@ fn process_single_file(
                     file_index: 0, // For a single file, the index is always 0
                     rel_path,
                     content: String::from_utf8_lossy(&content).to_string(),
+                    outline_level: None,
                 });
             }
         }
@@ -168,6 +172,7 @@ fn process_files_parallel_internal(
                             file_index: 0, // assigned later
                             rel_path,
                             content: String::from_utf8_lossy(&content).to_string(),
+                            outline_level: None,
                         });
                     }
                     Err(e) => {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -568,7 +568,10 @@ fn test_outline_defaults_off() {
     assert_eq!(config.outline_mode, None);
     assert_eq!(config.outline_mode(), yek::config::OutlineMode::Off);
     assert_eq!(config.outline_level(), yek::config::OutlineLevel::Outline);
-    assert_eq!(config.outline_fallback(), yek::config::OutlineFallback::Full);
+    assert_eq!(
+        config.outline_fallback(),
+        yek::config::OutlineFallback::Full
+    );
     assert!(!config.outline_active());
     assert!(config.validate().is_ok());
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -560,3 +560,35 @@ fn test_is_text_file_with_binary_content() {
         "Expected a binary file to be detected as binary"
     );
 }
+
+#[test]
+fn test_outline_defaults_off() {
+    let config =
+        YekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
+    assert_eq!(config.outline_mode, None);
+    assert_eq!(config.outline_mode(), yek::config::OutlineMode::Off);
+    assert_eq!(config.outline_level(), yek::config::OutlineLevel::Outline);
+    assert_eq!(config.outline_fallback(), yek::config::OutlineFallback::Full);
+    assert!(!config.outline_active());
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn test_outline_active_when_set() {
+    let mut config =
+        YekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
+    config.outline_mode = Some(yek::config::OutlineMode::Degrade);
+    assert!(config.outline_active());
+    assert_eq!(config.outline_mode(), yek::config::OutlineMode::Degrade);
+}
+
+#[cfg(feature = "outline")]
+#[test]
+fn test_outline_rejects_unknown_language() {
+    let mut config =
+        YekConfig::extend_config_with_defaults(vec![".".to_string()], "output".to_string());
+    config.outline_languages = vec!["rust".to_string(), "cobol".to_string()];
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("outline_languages"), "got: {err}");
+    assert!(err.contains("cobol"), "got: {err}");
+}

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -503,12 +503,14 @@ mod lib_tests {
             ProcessedFile {
                 priority: 100,
                 file_index: 0,
+                outline_level: None,
                 rel_path: "src/main.rs".to_string(),
                 content: "fn main() {}".to_string(),
             },
             ProcessedFile {
                 priority: 50,
                 file_index: 1,
+                outline_level: None,
                 rel_path: "README.md".to_string(),
                 content: "# Yek".to_string(),
             },
@@ -545,6 +547,7 @@ mod lib_tests {
         let files = vec![ProcessedFile {
             priority: 100,
             file_index: 0,
+            outline_level: None,
             rel_path: "file with ünicöde.txt".to_string(),
             content: "content".to_string(),
         }];
@@ -562,6 +565,7 @@ mod lib_tests {
         let files = vec![ProcessedFile {
             priority: 100,
             file_index: 0,
+            outline_level: None,
             rel_path: "file.txt".to_string(),
             content: "".to_string(), // Empty content
         }];
@@ -579,6 +583,7 @@ mod lib_tests {
         let files = vec![ProcessedFile {
             priority: 100,
             file_index: 0,
+            outline_level: None,
             rel_path: "file.txt".to_string(),
             content: "".to_string(), // Empty content
         }];
@@ -605,6 +610,7 @@ mod lib_tests {
             content: "Hello world".to_string(),
             priority: 0,
             file_index: 0,
+            outline_level: None,
         }];
         let output = concat_files(&files, &config).unwrap();
         let tokens = count_tokens(&output);
@@ -623,6 +629,7 @@ mod lib_tests {
             content: "Hello world".to_string(),
             priority: 0,
             file_index: 0,
+            outline_level: None,
         }];
         let output = concat_files(&files, &config).unwrap();
         let tokens = count_tokens(&output);
@@ -645,12 +652,14 @@ mod lib_tests {
                 content: "This is a short test".to_string(),
                 priority: 0,
                 file_index: 0,
+                outline_level: None,
             },
             ProcessedFile {
                 rel_path: "test2.txt".to_string(),
                 content: "This is another test that should be excluded".to_string(),
                 priority: 0,
                 file_index: 1,
+                outline_level: None,
             },
         ];
         let output = concat_files(&files, &config).unwrap();
@@ -662,6 +671,43 @@ mod lib_tests {
         assert!(
             !output.contains("test2.txt"),
             "Expected file test2.txt to be excluded"
+        );
+    }
+
+    #[test]
+    fn test_oversized_high_priority_does_not_drop_smaller_files() {
+        // Regression: an oversized high-priority file must be skipped without
+        // wiping smaller, lower-priority files that still fit.
+        let config = YekConfig {
+            token_mode: true,
+            tokens: "20".to_string(),
+            output_template: ">>>> FILE_PATH\nFILE_CONTENT".to_string(),
+            ..Default::default()
+        };
+        let files = vec![
+            ProcessedFile {
+                rel_path: "big.txt".to_string(),
+                content: "word ".repeat(100), // far exceeds the 20-token cap
+                priority: 100,
+                file_index: 0,
+                outline_level: None,
+            },
+            ProcessedFile {
+                rel_path: "small.txt".to_string(),
+                content: "tiny".to_string(),
+                priority: 1,
+                file_index: 1,
+                outline_level: None,
+            },
+        ];
+        let output = concat_files(&files, &config).unwrap();
+        assert!(
+            output.contains("small.txt"),
+            "small lower-priority file should survive: {output}"
+        );
+        assert!(
+            !output.contains("big.txt"),
+            "oversized high-priority file should be skipped: {output}"
         );
     }
 

--- a/tests/outline_e2e_test.rs
+++ b/tests/outline_e2e_test.rs
@@ -44,7 +44,10 @@ fn fallback_full_keeps_unsupported_verbatim() {
 
     let (out, files) = serialize_repo(&cfg).unwrap();
 
-    assert!(out.contains("body text"), "unsupported file should be verbatim");
+    assert!(
+        out.contains("body text"),
+        "unsupported file should be verbatim"
+    );
     let md = files.iter().find(|f| f.rel_path == "notes.md").unwrap();
     assert_eq!(md.outline_level, None);
 }
@@ -61,7 +64,10 @@ fn fallback_omit_drops_unsupported() {
     let (out, files) = serialize_repo(&cfg).unwrap();
 
     assert!(files.iter().any(|f| f.rel_path == "a.rs"));
-    assert!(!files.iter().any(|f| f.rel_path == "notes.md"), "md not omitted");
+    assert!(
+        !files.iter().any(|f| f.rel_path == "notes.md"),
+        "md not omitted"
+    );
     assert!(!out.contains("body text"));
 }
 
@@ -74,7 +80,10 @@ fn json_output_includes_level_field() {
     cfg.json = true;
 
     let (out, _) = serialize_repo(&cfg).unwrap();
-    assert!(out.contains("\"level\""), "json level field missing:\n{out}");
+    assert!(
+        out.contains("\"level\""),
+        "json level field missing:\n{out}"
+    );
     assert!(out.contains("\"outline\""));
 }
 
@@ -97,14 +106,27 @@ fn degrade_keeps_high_priority_full_and_outlines_rest() {
     cfg.token_mode = true;
     cfg.tokens = "80".to_string();
     cfg.priority_rules = vec![
-        PriorityRule { pattern: "important.rs".to_string(), score: 100 },
-        PriorityRule { pattern: "minor.rs".to_string(), score: 1 },
+        PriorityRule {
+            pattern: "important.rs".to_string(),
+            score: 100,
+        },
+        PriorityRule {
+            pattern: "minor.rs".to_string(),
+            score: 1,
+        },
     ];
 
     let (_out, files) = serialize_repo(&cfg).unwrap();
 
     let important = files.iter().find(|f| f.rel_path == "important.rs").unwrap();
     let minor = files.iter().find(|f| f.rel_path == "minor.rs").unwrap();
-    assert_eq!(important.outline_level, None, "high-priority file should stay full");
-    assert_eq!(minor.outline_level, Some("outline"), "low-priority file should be outlined");
+    assert_eq!(
+        important.outline_level, None,
+        "high-priority file should stay full"
+    );
+    assert_eq!(
+        minor.outline_level,
+        Some("outline"),
+        "low-priority file should be outlined"
+    );
 }

--- a/tests/outline_e2e_test.rs
+++ b/tests/outline_e2e_test.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "outline")]
+//! End-to-end tests for outline mode wired through `serialize_repo`.
+
+use std::fs;
+use tempfile::TempDir;
+use yek::config::{OutlineFallback, OutlineMode, YekConfig};
+use yek::priority::PriorityRule;
+use yek::serialize_repo;
+
+fn config_for(dir: &TempDir) -> YekConfig {
+    YekConfig::extend_config_with_defaults(
+        vec![dir.path().to_string_lossy().to_string()],
+        dir.path().join("out").to_string_lossy().to_string(),
+    )
+}
+
+const RS_FILE: &str = "pub fn foo() {\n    let x = 1;\n    let y = 2;\n    let z = 3;\n}\n";
+
+#[test]
+fn always_outlines_rust_files() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), RS_FILE).unwrap();
+    let mut cfg = config_for(&dir);
+    cfg.outline_mode = Some(OutlineMode::Always);
+
+    let (out, files) = serialize_repo(&cfg).unwrap();
+
+    assert!(out.contains("pub fn foo()"), "signature missing:\n{out}");
+    assert!(out.contains("/* …"), "body not elided:\n{out}");
+    assert!(!out.contains("let x = 1"), "body leaked:\n{out}");
+    assert!(out.contains("⟪yek:outline⟫"), "marker missing:\n{out}");
+
+    let a = files.iter().find(|f| f.rel_path == "a.rs").unwrap();
+    assert_eq!(a.outline_level, Some("outline"));
+}
+
+#[test]
+fn fallback_full_keeps_unsupported_verbatim() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), RS_FILE).unwrap();
+    fs::write(dir.path().join("notes.md"), "# Title\nbody text\n").unwrap();
+    let mut cfg = config_for(&dir);
+    cfg.outline_mode = Some(OutlineMode::Always); // fallback defaults to full
+
+    let (out, files) = serialize_repo(&cfg).unwrap();
+
+    assert!(out.contains("body text"), "unsupported file should be verbatim");
+    let md = files.iter().find(|f| f.rel_path == "notes.md").unwrap();
+    assert_eq!(md.outline_level, None);
+}
+
+#[test]
+fn fallback_omit_drops_unsupported() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), RS_FILE).unwrap();
+    fs::write(dir.path().join("notes.md"), "# Title\nbody text\n").unwrap();
+    let mut cfg = config_for(&dir);
+    cfg.outline_mode = Some(OutlineMode::Always);
+    cfg.outline_fallback = Some(OutlineFallback::Omit);
+
+    let (out, files) = serialize_repo(&cfg).unwrap();
+
+    assert!(files.iter().any(|f| f.rel_path == "a.rs"));
+    assert!(!files.iter().any(|f| f.rel_path == "notes.md"), "md not omitted");
+    assert!(!out.contains("body text"));
+}
+
+#[test]
+fn json_output_includes_level_field() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), RS_FILE).unwrap();
+    let mut cfg = config_for(&dir);
+    cfg.outline_mode = Some(OutlineMode::Always);
+    cfg.json = true;
+
+    let (out, _) = serialize_repo(&cfg).unwrap();
+    assert!(out.contains("\"level\""), "json level field missing:\n{out}");
+    assert!(out.contains("\"outline\""));
+}
+
+#[test]
+fn degrade_keeps_high_priority_full_and_outlines_rest() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("important.rs"),
+        "pub fn important_thing() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("minor.rs"),
+        "pub fn minor_thing() {\n    let x = 10;\n    let y = 20;\n    let z = 30;\n}\n",
+    )
+    .unwrap();
+
+    let mut cfg = config_for(&dir);
+    cfg.outline_mode = Some(OutlineMode::Degrade);
+    cfg.token_mode = true;
+    cfg.tokens = "80".to_string();
+    cfg.priority_rules = vec![
+        PriorityRule { pattern: "important.rs".to_string(), score: 100 },
+        PriorityRule { pattern: "minor.rs".to_string(), score: 1 },
+    ];
+
+    let (_out, files) = serialize_repo(&cfg).unwrap();
+
+    let important = files.iter().find(|f| f.rel_path == "important.rs").unwrap();
+    let minor = files.iter().find(|f| f.rel_path == "minor.rs").unwrap();
+    assert_eq!(important.outline_level, None, "high-priority file should stay full");
+    assert_eq!(minor.outline_level, Some("outline"), "low-priority file should be outlined");
+}


### PR DESCRIPTION
## What

Implements **outline mode** (issue #245): replaces file contents with compact structural **skeletons** — imports, type/function signatures, bodies elided — so far more of a repo fits in a fixed `--tokens` budget. Built on tree-sitter, **opt-in behind the `outline` Cargo feature** so the default build stays slim and language-agnostic.

Started as a design doc; this PR now also contains a working **Rust** implementation in focused, individually-reviewed commits.

## Commits

1. **docs** — the design plan (`docs/outline-plan.md`) + detailed, perf-aware implementation plan.
2. **engine** — `src/outline/`: `Full/Outline/Api/Symbols` levels via a field-based tree walk (parse once → byte-range `Symbol`s, render on demand); attribute + doc-comment capture; depth re-indentation; `MAX_SYMBOLS`/error-ratio guards.
3. **config/CLI** — `--outline[-mode|-level|-languages|-fallback]` + matching `yek.yaml` keys (Option-typed so config files actually merge); feature-off warning.
4. **pipeline** — `apply` runs before the budget step. `always` outlines every supported file; `degrade` keeps the highest-priority files full and outlines the rest. Text marks abbreviated files with `⟪yek:LEVEL⟫`; `--json` gains a `level` field. Also fixes a pre-existing budget bug (`concat_files` dropped the *most* important files under a tight cap).
5. **docs** — README usage + implementation-status notes.
6. **ci** — build/test the `outline` feature; rustfmt.

## Example

```
$ yek --outline               # structural map of the whole repo
$ yek --outline-mode degrade --tokens 128k   # important files full, rest outlined
```

```rust
⟪yek:outline⟫
/// A cache.
#[derive(Debug)]
pub struct Cache { map: HashMap<String, u32> }
impl Cache {
    pub fn new() -> Self { /* … */ }
    fn evict(&mut self) { /* … */ }
}
pub fn helper(n: u32) -> u32 { /* … 3 lines … */ }
```

## Review & testing

Each code commit was reviewed with the `code-review` skill; findings were addressed (notably: single-line containers no longer duplicate headers/leak bodies; an oversized high-priority file no longer wipes smaller files; doc/attribute capture; honest macro handling). Unit + e2e tests cover extraction, all levels, multibyte input, and always/degrade/fallback/json. `cargo test`/`clippy`/`fmt` pass in both build configs (two local IO tests fail only because this sandbox runs as root, bypassing `chmod 000`; they pass as non-root in CI).

## Status / scope

Rust only; `degrade` is the simpler "half-budget" v1 (the exact suffix-floor allocator, more languages, and MCP/lazy-retrieval are tracked as follow-ups in the plan's §17). Still a draft pending maintainer direction on scope and whether prebuilt binaries should ship with the feature on.

Related: #245 (lazy retrieval), #232 (MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVZKnvf46uJpwqqrSQECmx